### PR TITLE
Add min-count to the processing of clusters

### DIFF
--- a/src/utils/ModelUtils.js
+++ b/src/utils/ModelUtils.js
@@ -89,10 +89,15 @@ export function getServerRoles (model) {
           .map(s => getCleanedServer(s))          // filter out any extra fields
           .sort((a,b) => byServerNameOrId(a,b))   // sort servers by name or id within each role
       };
-      if (group === 'clusters')
-        role['memberCount'] = res['member-count'] || res['min-count'] || 0;
-      else
+      if (group === 'clusters') {
+        if (res['member-count'] || res['member-count'] === 0) {
+          role['memberCount'] = res['member-count'];
+        } else if (res['min-count'] || res['min-count'] === 0) {
+          role['minCount'] = res['min-count'];
+        }
+      } else {
         role['minCount'] = res['min-count'] || 0;
+      }
       return role;
     }));
   }

--- a/src/utils/ModelUtils.js
+++ b/src/utils/ModelUtils.js
@@ -90,7 +90,7 @@ export function getServerRoles (model) {
           .sort((a,b) => byServerNameOrId(a,b))   // sort servers by name or id within each role
       };
       if (group === 'clusters')
-        role['memberCount'] = res['member-count'] || 0;
+        role['memberCount'] = res['member-count'] || res['min-count'] || 0;
       else
         role['minCount'] = res['min-count'] || 0;
       return role;


### PR DESCRIPTION
SCRD-2032 The entry-scale-kvm-ceph model uses both member-count and min-count in the clusters definition but the code only looks at member-count. I also found two other models that have min-count in their clusters definition: entry-scal-kvm-esx-vsa-mml (controller nodes) and entry-scale-kvm-vsa-mml (controller nodes).