### PR TITLE
Fixed bugs based on UX feedback

### DIFF
--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -38,7 +38,7 @@ function NextButton(props) {
 
 class ActionButton extends Component {
   render() {
-    let buttonClass = 'btn ' + (this.props.type ? 'btn-' + this.props.type : 'btn-primary ') +
+    let buttonClass = 'btn ' + (this.props.type ? 'btn-' + this.props.type + ' ' : 'btn-primary ') +
       (this.props.isDisabled ? ' disabled' : '');
     buttonClass += (this.props.lastButton) ? 'last-button' : '';
     return (
@@ -99,7 +99,7 @@ class LoadFileButton extends Component {
     const hidden = { display: 'none' };
     return (
       <span>
-        <ActionButton
+        <ActionButton type='link'
           clickAction={this.onClickShownButton}
           displayLabel={this.props.displayLabel}
           isDisabled={this.props.isDisabled || false}
@@ -125,9 +125,16 @@ class PickerButton extends Component {
   render() {
     let classN = 'picker-card rounded-corner shadowed-border' +
       (this.props.isSelected ? ' selected' : '');
+    let check = '';
+    if(this.props.isSelected) {
+      check = (<i className="material-icons model-check-icon">check_circle</i>);
+    }
     return (
       <div className={classN} name={this.props.keyName}
-        onClick={this.props.clickAction}>{this.props.displayLabel}</div>
+        onClick={this.props.clickAction}>
+        <p onClick={this.props.clickAction} name={this.props.keyName}>{this.props.displayLabel}</p>
+        <p className='model-check'>{check}</p>
+      </div>
     );
   }
 }
@@ -146,6 +153,10 @@ class ActivePickerButton extends Component {
 
   render() {
     let buttonClass = 'model-elements' + (this.props.isSelected ? ' model-element-selected' : '');
+    let check = '';
+    if(this.props.isSelected) {
+      check = (<i className="material-icons model-check-icon">check_circle</i>);
+    }
     return (
       <div className={buttonClass}>
         <div
@@ -153,12 +164,13 @@ class ActivePickerButton extends Component {
           className='card rounded-corner shadowed-border'
           onClick={this.handleClick}
           value={this.props.value} >
-          <p className='card-text-unit' id={this.props.id}>
+          <p className='card-text-unit' id={this.props.id} >
             {this.props.value}
           </p>
           <h4 id={this.props.id}>
             {this.props.description}
           </h4>
+          <p className='element-check'>{check}</p>
         </div>
       </div>
     );

--- a/src/components/Messages.js
+++ b/src/components/Messages.js
@@ -64,7 +64,15 @@ function SuccessMessage(props) {
   );
 }
 
+function InfoBanner(props) {
+  return (
+    <Alert><span className='info-banner'>
+      <i className='material-icons info-icon'>info</i>{props.message}</span></Alert>
+  );
+}
+
 module.exports = {
   ErrorMessage: ErrorMessage,
-  SuccessMessage: SuccessMessage
+  SuccessMessage: SuccessMessage,
+  InfoBanner: InfoBanner
 };

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -29,6 +29,7 @@
     "logviewer.autoscroll": "Automatically scroll to the bottom",
     "no.options.available": "No options available",
     "no.component.select": "No Component Selected",
+    "no.model.select": "No Model Selected",
     "common.details": "Details",
 
     "install.intro.message.body1": "You are about to install a new cloud.",

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -28,6 +28,8 @@
     "wizard.loading.pleasewait": "Loading... Please wait",
     "logviewer.autoscroll": "Automatically scroll to the bottom",
     "no.options.available": "No options available",
+    "no.component.select": "No Component Selected",
+    "common.details": "Details",
 
     "install.intro.message.body1": "You are about to install a new cloud.",
     "install.intro.message.body2": "You will need to supply information about the servers, networks and storage that will make up your cloud. The OpenStack Cloud installer will then take care of deploying and configuring your new cloud for you.",
@@ -79,7 +81,8 @@
     "validate.config.files.heading": "Review Configuration Files",
     "validate.config.files.validate": "Validate",
     "validate.config.files.deploy": "Deploy",
-    "validate.config.files.msg.info": "Click on a configuration file to view or edit its content. Click the Validate button to run the configuration processor.",
+    "validate.config.files.msg.info1": "Click on a configuration file to view or edit its content.",
+    "validate.config.files.msg.info2": "Click the Validate button to run the configuration processor.",
     "validate.config.files.msg.valid": "The configuration processor completed successfully. Data model is valid.",
     "validate.config.files.msg.invalid": "The configuration processor failed with the following message: ",
     "validate.config.files.msg.validating": "Validating...",
@@ -104,7 +107,7 @@
     "add.server.auto.discover": "Auto Discover",
     "add.server.manual.add": "Manual Discover",
     "add.server.add": "Add Server",
-    "add.server.add.csv": "Import From CSV",
+    "add.server.add.csv": "Import servers from CSV",
     "csv.import.error": "CSV import error",
     "add.server.discover": "Discover",
     "add.server.conf.discover": "Configure",
@@ -380,5 +383,6 @@
     "model.summary.role.description.SWPAC-ROLE" : "Describe SWPAC Nodes",
     "model.summary.role.description.NEUTRON-ROLE" : "Describe Neutron Nodes",
     "model.summary.role.description.IRONIC-COMPUTE-ROLE" : "Describe Ironic Compute Nodes",
-    "model.summary.role.description.NOT_FOUND" : "Describe the fact that the customer must have created this role"
+    "model.summary.role.description.NOT_FOUND" : "Describe the fact that the customer must have created this role",
+    "model.summary.role.component.NOT_FOUND": "Custom component type"
 }

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -1083,10 +1083,12 @@ class AssignServerRoles extends BaseWizardPage {
       // When there are no servers yet discovered, the tab shows just
       // two buttons instead of content
       return (
-        <div className='btn-row centered'>
-          <ActionButton
-            clickAction={this.handleAddServerManually}
-            displayLabel={translate('add.server.add')}/>
+        <div className='centered'>
+          <div className='stacked'>
+            <ActionButton
+              clickAction={this.handleAddServerManually}
+              displayLabel={translate('add.server.add')}/>
+          </div>
           <LoadFileButton
             clickAction={this.handleAddServerFromCSV}
             displayLabel={translate('add.server.add.csv')}/>

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -357,7 +357,7 @@ class CloudModelPicker extends BaseWizardPage {
     }
     else {
       detailContent =
-        (<div className='no-component-centered'>{translate('no.component.select')}</div>);
+        (<div className='no-component-centered'>{translate('no.model.select')}</div>);
     }
     return (<div className='details-container'>{detailContent}</div>);
   }

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -341,21 +341,38 @@ class CloudModelPicker extends BaseWizardPage {
     }
   }
 
+  renderDetails = () => {
+    let detailContent = '';
+    if(this.state.selectedModelName) {
+      let details = '';
+      const template = this.displayTemplates.find(template => template.name === this.state.selectedModelName);
+      if (template) {
+        // details is the html help content read from model template fetched from the backend server.
+        // It should be safe to be rendered as the raw html content in the details view.
+        details = template['overview'];
+      }
+      detailContent =
+        (<div><h3>{translate('model.picker.' + this.state.selectedModelName) + ' ' + translate('common.details')}</h3>
+          <div className='model-details' dangerouslySetInnerHTML={{__html: details}}/></div>);
+    }
+    else {
+      detailContent =
+        (<div className='no-component-centered'>{translate('no.component.select')}</div>);
+    }
+    return (<div className='details-container'>{detailContent}</div>);
+  }
+
   render() {
     this.displayTemplates = this.getDisplayTemplates();
-    const selectedTemplate = this.displayTemplates.find((template) => {
-      return template.name === this.state.selectedModelName;});
 
-    // details is the html help content read from model template fetched from the backend server.
-    // It should be safe to be rendered as the raw html content in the details view.
-    let details = selectedTemplate ? selectedTemplate.overview : '';
     const btns = this.displayTemplates.map((template, idx) =>
       <PickerButton
         key={idx}
         keyName={template.name}
         isSelected={template.name === this.state.selectedModelName}
         displayLabel={translate('model.picker.' + template.name)}
-        clickAction={this.handlePickModel}/>);
+        clickAction={this.handlePickModel}/>
+    );
 
     return (
       <div className='wizard-page'>
@@ -365,12 +382,8 @@ class CloudModelPicker extends BaseWizardPage {
         <div className='wizard-content'>
           {this.renderLoadingMask()}
           {this.renderFilterBar(this.displayTemplates)}
-          <div className='picker-container'>
-            {btns}
-          </div>
-          <div className='details-container'>
-            <div className='model-details' dangerouslySetInnerHTML={{__html: details}}/>
-          </div>
+          <div className='picker-container'>{btns}</div>
+          {this.renderDetails()}
           {this.renderErrorMessage()}
         </div>
         {this.renderNavButtons()}

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -17,6 +17,7 @@ import '../Deployer.css';
 import { translate } from '../localization/localize.js';
 import BaseWizardPage from './BaseWizardPage.js';
 import { ActivePickerButton } from '../components/Buttons.js';
+import { InfoBanner } from '../components/Messages.js';
 
 class CloudModelSummary extends BaseWizardPage {
   constructor(props) {
@@ -54,14 +55,14 @@ class CloudModelSummary extends BaseWizardPage {
       'NEUTRON-ROLE': translate('model.summary.role.displayname.NEUTRON-ROLE'),
       'IRONIC-COMPUTE-ROLE': translate('model.summary.role.displayname.IRONIC-COMPUTE-ROLE')
     };
-    var NOT_FOUND = 'Custom component type';
+    var NOT_FOUND = translate('model.summary.role.component.NOT_FOUND');
 
     return displayNames[role] || NOT_FOUND;
   }
 
   getDescription() {
-    if (! this.state.activeItem) {
-      return '';
+    if (!this.state.activeItem) {
+      return (<div className='no-component-centered'>{translate('no.component.select')}</div>);
     }
 
     //TODO: Improve these descriptions
@@ -82,7 +83,9 @@ class CloudModelSummary extends BaseWizardPage {
     };
     var NOT_FOUND = translate('model.summary.role.description.NOT_FOUND');
     var role = this.state.controlPlane.getIn(this.getKey(this.state.activeItem, 1)).get('server-role');
-    return descriptions[role] || NOT_FOUND;
+    let desc = descriptions[role] || NOT_FOUND;
+
+    return <InfoBanner message={desc} />;
   }
 
   // convert a delimited string (normally the state.activeItem) into a list.  Optionally

--- a/src/pages/ServerRoleSummary/DiskModelsTab.js
+++ b/src/pages/ServerRoleSummary/DiskModelsTab.js
@@ -109,13 +109,13 @@ class DiskModelsTab extends Component {
 
     let addClass = 'material-icons add-button';
     addClass = this.state.showDiskModelDetails ? addClass + ' disabled' : addClass;
+    let addTextClass = 'add-text';
+    addTextClass = this.state.showDiskModelDetails ? addTextClass + ' disabled' : addTextClass;
     let actionRow = (
       <tr key='diskModelAction' className='action-row'>
-        <td><i className={addClass} onClick={this.addDiskModel}>
-          add_circle</i>{translate('add.disk.model')}</td>
-        <td></td>
-        <td></td>
-        <td></td>
+        <td><i className={addClass} onClick={this.addDiskModel}>add_circle</i>
+          <span className={addTextClass} onClick={this.addDiskModel}>{translate('add.disk.model')}</span></td>
+        <td colSpan='3'/>
       </tr>
     );
 

--- a/src/pages/ServerRoleSummary/InterfaceModelsTab.js
+++ b/src/pages/ServerRoleSummary/InterfaceModelsTab.js
@@ -132,10 +132,12 @@ class InterfaceModelsTab extends Component {
   // Render the entire contents of the tab
   render() {
     let addClass = 'material-icons add-button';
+    let addTextClass = 'add-text';
     let editClass = 'glyphicon glyphicon-pencil edit-button';
     let removeClass = 'glyphicon glyphicon-trash remove-button';
     if (this.state.overallMode != MODE.NONE) {
       addClass += ' disabled';
+      addTextClass += ' disabled';
       editClass += ' disabled';
       removeClass += ' disabled';
     }
@@ -163,7 +165,7 @@ class InterfaceModelsTab extends Component {
       <tr key='addModel' className='action-row'>
         <td colSpan="3">
           <i className={addClass} onClick={this.addModel}>add_circle</i>
-          {translate('add.interface.model')}
+          <span className={addTextClass} onClick={this.addModel}>{translate('add.interface.model')}</span>
         </td>
       </tr>
     );

--- a/src/pages/ServerRoleSummary/NetworksTab.js
+++ b/src/pages/ServerRoleSummary/NetworksTab.js
@@ -75,11 +75,13 @@ class NetworksTab extends Component {
   renderActionRow() {
     let addClass = 'material-icons add-button';
     addClass = this.state.mode !== MODE.NONE ? addClass + ' disabled' : addClass;
+    let addTextClass = 'add-text';
+    addTextClass = this.state.mode !== MODE.NONE ? addTextClass + ' disabled' : addTextClass;
     return (
       <tr key='networkAction' className='action-row'>
         <td><i className={addClass} onClick={this.handleAddNetwork}>add_circle</i>
-          {translate('add.network')}</td>
-        <td colSpan="5"/>
+          <span className={addTextClass} onClick={this.handleAddNetwork}>{translate('add.network')}</span></td>
+        <td colSpan='5'/>
       </tr>
     );
   }

--- a/src/pages/ServerRoleSummary/NicMappingTab.js
+++ b/src/pages/ServerRoleSummary/NicMappingTab.js
@@ -268,10 +268,12 @@ class NicMappingTab extends Component {
   render() {
 
     let addClass = 'material-icons add-button';
+    let addTextClass = 'add-text';
     let editClass = 'glyphicon glyphicon-pencil edit-button';
     let removeClass = 'glyphicon glyphicon-trash remove-button';
     if (this.state.mode != MODE.NONE) {
       addClass += ' disabled';
+      addTextClass += ' disabled';
       editClass += ' disabled';
       removeClass += ' disabled';
     }
@@ -298,7 +300,7 @@ class NicMappingTab extends Component {
       <tr key='addNicMapping' className='action-row'>
         <td colSpan="3">
           <i className={addClass} onClick={this.addNicMapping}>add_circle</i>
-          {translate('add.nic.mapping')}
+          <span className={addTextClass} onClick={this.addNicMapping}>{translate('add.nic.mapping')}</span>
         </td>
       </tr>
     );

--- a/src/pages/ServerRoleSummary/ServerGroupsTab.js
+++ b/src/pages/ServerRoleSummary/ServerGroupsTab.js
@@ -106,13 +106,13 @@ class ServerGroupsTab extends Component {
 
     let addClass = 'material-icons add-button';
     addClass = this.state.showServerGroupDetails ? addClass + ' disabled' : addClass;
+    let addTextClass = 'add-text';
+    addTextClass = this.state.showServerGroupDetails ? addTextClass + ' disabled' : addTextClass;
     let actionRow = (
       <tr key='serverGroupAction' className='action-row'>
-        <td><i className={addClass} onClick={this.addServerGroup}>
-          add_circle</i>{translate('add.server.group')}</td>
-        <td></td>
-        <td></td>
-        <td></td>
+        <td><i className={addClass} onClick={this.addServerGroup}>add_circle</i>
+          <span className={addTextClass} onClick={this.addServerGroup}>{translate('add.server.group')}</span></td>
+        <td colSpan='3'/>
       </tr>
     );
 

--- a/src/pages/ValidateConfigFiles.js
+++ b/src/pages/ValidateConfigFiles.js
@@ -24,6 +24,7 @@ import { Tabs, Tab } from 'react-bootstrap';
 import ServiceTemplatesTab from './ValidateConfigFiles/ServiceTemplatesTab.js';
 import Dropdown from '../components/Dropdown.js';
 import HelpText from '../components/HelpText.js';
+import { InfoBanner } from '../components/Messages.js';
 
 const INVALID = 0;
 const VALID = 1;
@@ -104,9 +105,16 @@ class EditFile extends Component {
 class DisplayFileList extends Component {
   getMessage() {
     if (this.props.valid === UNKNOWN) {
-      return (<div>{translate('validate.config.files.msg.info')}</div>);
+      return (
+        <div>
+          <InfoBanner message={translate('validate.config.files.msg.info1')}/>
+          <InfoBanner message={translate('validate.config.files.msg.info2')}/>
+        </div>);
     } else if (this.props.valid === VALIDATING) {
-      return (<div>{translate('validate.config.files.msg.validating')}</div>);
+      return (
+        <div> <i className='material-icons refresh-icon'>refresh</i>
+          {translate('validate.config.files.msg.validating')}</div>
+      );
     } else if (this.props.valid === VALID) {
       return (<div>{translate('validate.config.files.msg.valid')}</div>);
     } else {
@@ -119,7 +127,7 @@ class DisplayFileList extends Component {
     if (this.props.valid === VALID) {
       return (<i className='material-icons validate-result-icon valid'>check_circle</i>);
     } else if (this.props.valid === INVALID) {
-      return (<i className='material-icons validate-result-icon invalid'>cancel</i>);
+      return (<i className='material-icons validate-result-icon invalid'>error</i>);
     }
   }
 
@@ -151,7 +159,7 @@ class DisplayFileList extends Component {
           </div>
           <div>
             <ActionButton
-              className='button-with-icon'
+              isDisabled={this.props.valid === VALIDATING}
               displayLabel={translate('validate.config.files.validate')}
               clickAction={() => this.props.onValidateClick()}/>
             {this.getIcon()}

--- a/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
+++ b/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
@@ -17,7 +17,7 @@ import { translate } from '../../localization/localize.js';
 import { ActionButton } from '../../components/Buttons.js';
 import { alphabetically } from '../../utils/Sort.js';
 import { fetchJson, postJson } from '../../utils/RestUtils.js';
-import { ErrorMessage } from '../../components/Messages.js';
+import { ErrorMessage, InfoBanner } from '../../components/Messages.js';
 import { ServerInput } from '../../components/ServerUtils.js';
 
 class EditTemplateFile extends Component {
@@ -161,7 +161,8 @@ class ServiceTemplatesTab extends Component {
       );
     }
     else {
-      return (<div className='col-xs-6'>{translate(('validate.config.service.info'))}</div>);
+      let desc = translate('validate.config.service.info');
+      return (<div className='col-xs-6'><InfoBanner message={desc}/></div>);
     }
   }
 
@@ -179,10 +180,8 @@ class ServiceTemplatesTab extends Component {
         });
       return (
         <li key={index}>
-          <span className='service-heading'>
-            <i className='material-icons'
-              onClick={() => this.handleToggleService(item)}>keyboard_arrow_down</i>
-            {item.service}</span>
+          <span className='service-heading' onClick={() => this.handleToggleService(item)}>
+            <i className='material-icons'>keyboard_arrow_down</i>{item.service}</span>
           <ul className='file-list'>{fileList}</ul>
         </li>
       );
@@ -190,10 +189,8 @@ class ServiceTemplatesTab extends Component {
     else { // when service not expanded
       return (
         <li key={index}>
-          <span className='service-heading'>
-            <i className='material-icons'
-              onClick={() => this.handleToggleService(item)}>keyboard_arrow_right</i>
-            {item.service}</span>
+          <span className='service-heading' onClick={() => this.handleToggleService(item)}>
+            <i className='material-icons'>keyboard_arrow_right</i>{item.service}</span>
         </li>
       );
     }

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -194,12 +194,3 @@ p {
 .tooltip-icon {
   margin-left: 4px;
 }
-
-#helptext > .tooltip-inner {
-  background-color: @preferredcolor;
-  color: white;
-  border: 1px solid @preferredcolor;
-}
-#helptext > .tooltip-arrow {
-  border-top: 5px solid @preferredcolor;
-}

--- a/src/styles/components/buttons.less
+++ b/src/styles/components/buttons.less
@@ -91,7 +91,7 @@
 
 .card-text-unit {
   font-size: 1.4em;
-  margin-top: 10px;
+  margin-top: 5px;
 }
 
 .model-elements div {
@@ -104,6 +104,12 @@
   float: left;
   min-height: 1px;
   cursor: pointer;
+  position: relative;
+  .element-check {
+    position: absolute;
+    left: 40%;
+    top: 75%;
+  }
 }
 
 .model-element-selected div {
@@ -122,10 +128,22 @@
   margin: 10px;
   cursor: pointer;
   text-align: center;
+  position: relative;
   &.selected {
     background-color: @preferredcolor;
     color: white;
   }
+  .model-check {
+    position: absolute;
+    left: 40%;
+    top: 70%;
+  }
+}
+
+.model-check-icon {
+  font-size: 28px;
+  background-color: @preferredcolor;
+  color: white;
 }
 
 .assignment-button {

--- a/src/styles/components/messages.less
+++ b/src/styles/components/messages.less
@@ -29,3 +29,12 @@
   margin: 3em;
   font-size: 1.4em;
 }
+
+.info-banner {
+  .info-icon {
+    font-size: 18px;
+    margin-right: 1em;
+    cursor: default;
+    vertical-align: middle;
+  }
+}

--- a/src/styles/components/modelpicker.less
+++ b/src/styles/components/modelpicker.less
@@ -35,6 +35,19 @@
   max-height: 40em;
   overflow: auto;
   vertical-align: top;
+  position: relative;
+}
+
+.no-component-centered {
+  position: absolute;
+  top: 50%;
+  left: 40%;
+}
+
+.details-container > div > h3 {
+  padding-bottom: 0.5em;
+  margin-bottom: 2em;
+  border-bottom: 1px solid @box-border-color;
 }
 
 .filter-bar-container {

--- a/src/styles/components/wizard.less
+++ b/src/styles/components/wizard.less
@@ -40,7 +40,7 @@
     }
     &.done:before {
       font-family: Material Icons;
-      content: "\e86c";
+      content: '\E876';
       padding-left: 4px;
     }
 

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -28,9 +28,6 @@
     background-color: white;
     margin-top: 1em;
   }
-  .button-with-icon {
-    margin-top: 1.2em;
-  }
   .validate-result-icon {
     position: relative;
     top: 0.4em;
@@ -41,6 +38,14 @@
     &.invalid {
       color: @errorcolor;
     }
+  }
+  .refresh-icon {
+    animation: spin 3s infinite 0.5s linear;
+  }
+
+  @keyframes spin {
+    from {transform:rotate(0deg);}
+    to {transform:rotate(360deg);}
   }
 }
 
@@ -99,6 +104,7 @@
   .service-heading {
     display: inline-flex;
     line-height: 1.5em;
+    cursor: pointer;
   }
 }
 

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -41,6 +41,7 @@
   }
   .refresh-icon {
     animation: spin 3s infinite 0.5s linear;
+    cursor: default;
   }
 
   @keyframes spin {

--- a/src/styles/pages/AssignServerRoles.less
+++ b/src/styles/pages/AssignServerRoles.less
@@ -176,9 +176,13 @@
     left: 50%;
     transform: translate(-50%, -50%);
   }
+  .stacked {
+    text-align: center;
+  }
 
   .role-accordion-container {
     height: 43.5em;
+    background: @table-header-gradient-color;
   }
 }
 

--- a/src/styles/pages/ServerRoleSummary.less
+++ b/src/styles/pages/ServerRoleSummary.less
@@ -24,6 +24,14 @@
     height: 4em;
   }
 
+  .add-text {
+    cursor: pointer;
+    &.disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
   .add-button {
     padding-right: 5px;
     font-size: 16px;


### PR DESCRIPTION
Then changes include: 

1. When no model is selected, model selection details pane should say "No model selected"
2. When a model is selected, model selection details pane should include a title with the model name.  3. The selected checker button should have a check . 
4. When no component is selected, the component details pane should say "No component selected"
5. When a component is selected, the information describing it should be in an info box with an info icon, The selected checker button should have a check . 
6. The model assignment accordion should not have blank space below the final entry if that entry is not expanded 
7. Add <component> links in Manage Cloud settings should be clickable on the text and icon, not just the icon
8. Check icon in wizard progress bubbles should be replaced with "done" icon form material icons library
9. Templates and Services tree should expand/collapse on text click in addition to arrow-click
10. Tooltips should have default bootstrap background (black)
11. failed deployments should use a smaller error icon (the ! looking one) 
12. While model validation is going on, the validate button should be disabled and there should be a spinning refresh icon next to "validating"
13. Separate out text instructions on Review Configuration Files page into info blocks 
14. "Import from csv" on assign servers page should be updated to be a link rather than a button 