### PR TITLE
Show user-friendly name of selected model after selection

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -320,10 +320,16 @@ class InstallWizard extends Component {
    * boilerplate ReactJS render function
    */
   render() {
+    const selectedModelLine = (this.state.currentStep >= 2 && this.state.model.get('name')) ?
+      <h3 className='right-corner'>{translate('model.picker.' + this.state.model.get('name'))}</h3> : '';
+
     return (
       <div>
         <div className='wizard-header'>
-          <h1>{translate('openstack.cloud.deployer.title')}</h1>
+          <div className='top-line'>
+            <h1>{translate('openstack.cloud.deployer.title')}</h1>
+            {selectedModelLine}
+          </div>
           <WizardProgress steps={this.state.steps} />
         </div>
         <div className='wizard-content-container'>

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -70,7 +70,7 @@
     "model.picker.filter.network-type.option.flat": "Flat Network",
     "model.picker.filter.network-type.option.multi-tenant": "Multi-tenant Network",
 
-    "model.summary.heading": "Cloud Model to Deploy: {0}",
+    "model.summary.heading": "Cloud Model to Deploy",
     "model.summary.mandatory": "Mandatory Components",
     "model.summary.additional": "Additional Components",
     "model.summary.edit.nodes": "Edit number of nodes",
@@ -100,7 +100,7 @@
 
     "edit.config.files.heading": "Update Configuration File: {0} ({1})",
 
-    "add.server.heading": "Add Servers and Assign Server Roles: {0}",
+    "add.server.heading": "Add Servers and Assign Server Roles",
     "add.server.auto.discover": "Auto Discover",
     "add.server.manual.add": "Manual Discover",
     "add.server.add": "Add Server",

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -1280,7 +1280,7 @@ class AssignServerRoles extends BaseWizardPage {
     return (
       <div className='wizard-page'>
         <div className='content-header'>
-          {this.renderHeading(translate('add.server.heading', this.props.model.get('name')))}
+          {this.renderHeading(translate('add.server.heading'))}
         </div>
         <div id='AssignServerRoleId' className='wizard-content'>
           {this.renderServerRoleContent()}

--- a/src/pages/BaseWizardPage.js
+++ b/src/pages/BaseWizardPage.js
@@ -29,7 +29,7 @@ import {
 class BaseWizardPage extends Component {
 
   /**
-   * function to determine whether the page is in an error state.  Subclasses 
+   * function to determine whether the page is in an error state.  Subclasses
    * should override this and return true to prevent navigation
    */
   isError() {

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -168,7 +168,7 @@ class CloudModelSummary extends BaseWizardPage {
     return (
       <div className='wizard-page'>
         <div className='content-header'>
-          {this.renderHeading(translate('model.summary.heading', this.props.model.get('name')))}
+          {this.renderHeading(translate('model.summary.heading'))}
         </div>
         <div className='wizard-content'>
           <div className='picker-container'>

--- a/src/styles/components/wizard.less
+++ b/src/styles/components/wizard.less
@@ -74,6 +74,14 @@
 .wizard-header {
   margin: 0px;
   padding: 0px 20px;
+  .top-line {
+    display: flex;
+    .right-corner {
+      margin-left: auto;
+      position: relative;
+      top: 9px;
+    }
+  }
 }
 
 @button-height: 34px;   // the height of all buttons is 34px


### PR DESCRIPTION
SCRD-2026 Show user-friendly name on subsequent pages after the user made a model selection. The name is showed in the upper right hand corner of the page.

Also includes a fix for a lints complaint in BaseWizardPage.js.