### PR TITLE
Fixed discovery search to include ip and mac address

### DIFF
--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -1033,7 +1033,10 @@ class AssignServerRoles extends BaseWizardPage {
     //apply name and assignment filter here
     let filteredAvailableServers =
       servers.filter((server) => {
-        if(server.name.indexOf(this.state.searchFilterText) === -1) {
+        // search text applied to name , ip-addr and mac-addr
+        if(!(server.name.indexOf(this.state.searchFilterText) !== -1 ||
+          (server['ip-addr'] && server['ip-addr'].indexOf(this.state.searchFilterText) !== -1) ||
+          (server['mac-addr'] && server['mac-addr'].indexOf(this.state.searchFilterText) !== -1))) {
           return false;
         }
 


### PR DESCRIPTION
On assign server role, current search text only filters on server name.
The fix is to include IP address or MAC address