### PR TITLE
Fix Encryption parameters

### DIFF
--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -136,7 +136,11 @@ class CloudDeployProgress extends BaseWizardPage {
       // don't prompt "Are you sure?" questions for wipedisks
       payload['extraVars']['automate'] = 'true';
       if (this.props.deployConfig['encryptKey']) {
-        payload['extraVars']['encryptKey'] = this.props.deployConfig['encryptKey'];
+        payload['extraVars']['encrypt'] = this.props.deployConfig['encryptKey'];
+        payload['extraVars']['rekey'] = "";
+      } else {
+        payload['extraVars']['encrypt'] = "";
+        payload['extraVars']['rekey'] = "";
       }
     }
 


### PR DESCRIPTION
'encrypt' is the proper extraVar to use, not 'encryptKey'.
A blank 'rekey' should be provided to avoid config-processor asking for this.