### PR TITLE
Added addresses field to add/update network

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -229,6 +229,8 @@
     "network.add": "Add Network",
     "network.gateway": "Gateway IP",
     "network": "Network",
+    "network.addresses": "Addresses",
+
     "vlanid": "VLAN ID",
     "cidr": "CIDR",
     "gateway": "Gateway",
@@ -348,6 +350,7 @@
     "input.validator.networkinterface.error": "Please enter a valid network interface",
     "input.validator.vlanid.error": "Please enter a valid VLAN id (1-4094)",
     "input.validator.cidr.error": "Please enter a valid CIDR",
+    "input.validator.addresses.error": "Please enter a valid IP address or IP address range",
     "input.validator.uniquename.error": "Name exists, please specify a different name",
     "input.validator.name.spaces.error": "Name should not contain spaces",
     "input.validator.yaml.error": "Invalid YAML",
@@ -393,5 +396,9 @@
     "model.summary.role.description.OVSVAPP-ROLE" : "Describe OVSVAPP Nodes",
     "model.summary.role.description.IRONIC-COMPUTE-ROLE" : "Describe Ironic Compute Nodes",
     "model.summary.role.description.NOT_FOUND" : "Describe the fact that the customer must have created this role",
-    "model.summary.role.component.NOT_FOUND": "Custom Component Nodes"
+    "model.summary.role.component.NOT_FOUND": "Custom Component Nodes",
+
+    "tooltip.network.addresses": "IP addresses used to limit the network access. Addresses could be an IP range or an IP address. For example, 10.0.1.1-10.0.1.10 or 10.0.1.23",
+    "tooltip.network.cidr": "Network address in Classless Inter-Domain Routing notation, such as 10.0.1.0/24",
+    "tooltip.network.vlanid": "A valid VLAN id is an integer in the range of 1-4094."
 }

--- a/src/styles/pages/ServerRoleSummary.less
+++ b/src/styles/pages/ServerRoleSummary.less
@@ -122,6 +122,13 @@
         }
       }
 
+      .network-section, .detail-line, .server-input {
+         width: 100%;
+        input {
+          width: 100%;
+        }
+      }
+
       .field-container {
         width: 85%;
         display: flex;
@@ -152,6 +159,7 @@
     }
     &.network-section {
       width: 100%;
+      min-height: 48em;
     }
   }
 
@@ -215,11 +223,16 @@
     }
     .server-detail-select select {
       padding: 4px;
-      width: 90%;
+      width: 85%;
     }
     .details-section .details-body .server-input input {
       padding: 4px;
-      width: 90%;
+      width: 85%;
+    }
+
+    .details-section .details-body .dropdown-plus-minus .server-input input {
+      padding: 4px;
+      width: 100%;
     }
   }
 

--- a/src/utils/InputValidators.js
+++ b/src/utils/InputValidators.js
@@ -30,6 +30,8 @@ const NET_INTERFACE = /^[0-9a-zA-Z.:_]{1,16}$/;
 const CIDR =
   /^((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))\/(3[0-2]|[1-2]?[0-9])$/;
 const STRING_WITH_NO_SPACES = /^\S+$/;
+const IPV4ADDRESS_RANGE =
+  /^(?:(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\s*-\s*(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$/;  //eslint-disable-line max-len
 
 export function IpV4AddressValidator(ipAddress) {
   let retValue = {
@@ -170,6 +172,44 @@ export function CidrValidator(cidr) {
   };
 }
 
+export function AddressesValidator(addresses) {
+  let retValue = {
+    isValid: true,
+    errorMsg: ''
+  };
+
+  // just one IPV4 address
+  if(addresses && addresses.indexOf('-') === -1) {
+    if(IPV4ADDRESS.exec(addresses.trim()) === null) {
+      retValue.isValid = false;
+      retValue.errorMsg = translate('input.validator.addresses.error');
+      return retValue;
+    }
+  }
+
+  if(addresses && addresses.indexOf('-') !== -1) { // just one range
+    if (IPV4ADDRESS_RANGE.exec(addresses.trim()) === null) {
+      retValue.isValid = false;
+      retValue.errorMsg = translate('input.validator.addresses.error');
+      return retValue;
+    }
+
+    var ips = addresses.replace(/\s/g, '').split('-');
+    var s_ip = ips[0];
+    var e_ip = ips[1];
+    var s_ip_num = ipAddrToInt(s_ip);
+    var e_ip_num = ipAddrToInt(e_ip);
+
+    if (s_ip_num >= e_ip_num) {
+      retValue.isValid = false;
+      retValue.errorMsg = translate('input.validator.addresses.error');
+      return retValue;
+    }
+  }
+
+  return retValue;
+}
+
 export function UniqueNameValidator(name, props) {
   let retValue = {
     isValid: true,
@@ -198,3 +238,4 @@ export function YamlValidator(text) {
     return { isValid: false, errorMsg: translate('input.validator.yaml.error')};
   }
 }
+


### PR DESCRIPTION
This checkin includes:
1. Added addresses input fields to add/update network
2. Added addresses validation to validate the list like:
  1.1.2.2 - 1.1.2.3 or 1.1.2.34
  Only validate the format, don't validate if the range is reasonable, or addresses are
  within cidr.
3. Adjusted the styling for the network details section.
4. Added tooltip for cidr, vlanid and addresses to help user for network fields.
5. Mark the Server Group with * to indicate is required.