### PR TITLE
Fix progress back and forth after changing subnet or netmask

### DIFF
--- a/src/pages/AssignServerRoles/BaremetalSettings.js
+++ b/src/pages/AssignServerRoles/BaremetalSettings.js
@@ -18,6 +18,7 @@ import { ConfirmModal } from '../../components/Modals.js';
 import { IpV4AddressValidator, IpInNetmaskValidator, NetmaskValidator } from '../../utils/InputValidators.js';
 import { ServerInputLine } from '../../components/ServerUtils.js';
 import { ActionButton } from '../../components/Buttons.js';
+import { fromJS } from 'immutable';
 
 class BaremetalSettings extends Component {
 
@@ -67,7 +68,7 @@ class BaremetalSettings extends Component {
       netmask: this.state.netmask
     };
     let model = this.props.model;
-    model = model.updateIn(['inputModel', 'baremetal'], settings => newSettings);
+    model = model.updateIn(['inputModel', 'baremetal'], settings => fromJS(newSettings));
     this.props.updateGlobalState('model', model);
     this.origBaremetal.subnet = this.state.subnet;
     this.origBaremetal.netmask = this.state.netmask;


### PR DESCRIPTION
The problem is that after a subnet or netmask change from the ManageSubnet and Netmask modal on the Assign Server page, you can click the back button to go to the Cloud Model Summary page but then you can't click the Next button to come back to the Assign Server page again. This change fixes that behavior.