### PR TITLE
Ask for confirmation before exiting Manage Cloud Settings modal

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -215,6 +215,7 @@
     "server.secure": "Secured",
 
     "edit.cloud.settings": "Manage Cloud Settings",
+    "edit.cloud.settings.close.confirm": "You've selected to leave Manage Cloud Settings but you have unsaved changes. \n\n Are you sure you want to proceed?",
     "edit.nic.mappings": "NIC Mappings",
     "edit.server.groups": "Server Groups",
     "edit.networks": "Networks",

--- a/src/pages/ServerRoleSummary.js
+++ b/src/pages/ServerRoleSummary.js
@@ -27,9 +27,14 @@ class ServerRoleSummary extends BaseWizardPage {
     super(props);
 
     this.checkInputs = ['nic-mapping', 'server-group'];
-    this.state = {
-      expandedGroup: ['COMPUTE-ROLE'],
-    };
+
+    // expand COMPUTE-ROLE if available, otherwise expand the first group
+    const allGroups = this.props.model.getIn(['inputModel','server-roles']).map(e => e.get('name')).toJS();
+    if (allGroups.includes('COMPUTE-ROLE')) {
+      this.state = {expandedGroup: ['COMPUTE-ROLE']};
+    } else {
+      this.state = {expandedGroup: [allGroups[0]]};
+    }
   }
 
   expandAll() {

--- a/src/pages/ServerRoleSummary/DiskModelDetails.js
+++ b/src/pages/ServerRoleSummary/DiskModelDetails.js
@@ -661,7 +661,7 @@ class DiskModelDetails extends Component {
       }
     }
     this.props.updateGlobalState('model', model);
-    this.props.closeAction();
+    this.closeAction();
   }
 
   checkDiskModelDataToSave = () => {

--- a/src/pages/ServerRoleSummary/DiskModelsTab.js
+++ b/src/pages/ServerRoleSummary/DiskModelsTab.js
@@ -123,7 +123,8 @@ class DiskModelsTab extends Component {
     if (this.state.showDiskModelDetails) {
       detailsSection = (<DiskModelDetails model={this.props.model}
         diskModel={this.state.diskModel} updateGlobalState={this.props.updateGlobalState}
-        closeAction={this.hideDiskModelDetails} extendAction={this.setExtendedDetails}/>);
+        closeAction={this.hideDiskModelDetails} extendAction={this.setExtendedDetails}
+        setDataChanged={this.props.setDataChanged}/>);
     }
 
     let confirmRemoveSection = '';

--- a/src/pages/ServerRoleSummary/EditCloudSettings.js
+++ b/src/pages/ServerRoleSummary/EditCloudSettings.js
@@ -15,7 +15,7 @@
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { Tabs, Tab } from 'react-bootstrap';
-import { ConfirmModal } from '../../components/Modals.js';
+import { ConfirmModal, YesNoModal } from '../../components/Modals.js';
 import NicMappingTab from './NicMappingTab.js';
 import ServerGroupsTab from './ServerGroupsTab.js';
 import NetworksTab from './NetworksTab.js';
@@ -35,38 +35,70 @@ class EditCloudSettings extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      key: TAB.NIC_MAPPINGS
+      key: TAB.NIC_MAPPINGS,
+      showCloseConfirmation: false
     };
+    this.dataChanged = [false, false, false, false, false];
+  }
+
+  showConfirmCloseModal = () => {
+    if (this.dataChanged.find(change => change)) {
+      this.setState({showCloseConfirmation: true});
+    } else {
+      this.closeModals();
+    }
+  }
+
+  closeModals = () => {
+    this.setState({showCloseConfirmation: false});
+    this.props.onHide();
+  }
+
+  setDataChanged = (index, changed) => {
+    this.dataChanged[index] = changed;
   }
 
   render() {
     return (
-      <ConfirmModal
-        show={this.props.show}
-        title={translate('edit.cloud.settings')}
-        className={'cloud-settings'}
-        hideFooter='true'
-        onHide={this.props.onHide}>
+      <div>
+        <ConfirmModal
+          show={this.props.show}
+          title={translate('edit.cloud.settings')}
+          className={'cloud-settings'}
+          hideFooter='true'
+          onHide={this.showConfirmCloseModal}>
 
-        <Tabs id='editCloudSettings' activeKey={this.state.key} onSelect={(tabKey) => {this.setState({key: tabKey});}}>
-          <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
-            <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState} />
-          </Tab>
-          <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
-            <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState} />
-          </Tab>
-          <Tab eventKey={TAB.NETWORKS} title={translate('edit.networks')}>
-            <NetworksTab model={this.props.model} updateGlobalState={this.props.updateGlobalState} />
-          </Tab>
-          <Tab eventKey={TAB.DISK_MODELS} title={translate('edit.disk.models')}>
-            <DiskModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState} />
-          </Tab>
-          <Tab eventKey={TAB.INTERFACE_MODELS} title={translate('edit.interface.models')}>
-            <InterfaceModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState} />
-          </Tab>
-        </Tabs>
+          <Tabs id='editCloudSettings' activeKey={this.state.key}
+            onSelect={(tabKey) => {this.setState({key: tabKey});}}>
+            <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
+              <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+                setDataChanged={this.setDataChanged}/>
+            </Tab>
+            <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
+              <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+                setDataChanged={this.setDataChanged}/>
+            </Tab>
+            <Tab eventKey={TAB.NETWORKS} title={translate('edit.networks')}>
+              <NetworksTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+                setDataChanged={this.setDataChanged}/>
+            </Tab>
+            <Tab eventKey={TAB.DISK_MODELS} title={translate('edit.disk.models')}>
+              <DiskModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+                setDataChanged={this.setDataChanged}/>
+            </Tab>
+            <Tab eventKey={TAB.INTERFACE_MODELS} title={translate('edit.interface.models')}>
+              <InterfaceModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+                setDataChanged={this.setDataChanged}/>
+            </Tab>
+          </Tabs>
 
-      </ConfirmModal>
+        </ConfirmModal>
+
+        <YesNoModal show={this.state.showCloseConfirmation} title={translate('warning')}
+          yesAction={this.closeModals} noAction={() => this.setState({showCloseConfirmation: false})}>
+          {translate('edit.cloud.settings.close.confirm')}
+        </YesNoModal>
+      </div>
     );
   }
 }

--- a/src/pages/ServerRoleSummary/InterfaceModelsTab.js
+++ b/src/pages/ServerRoleSummary/InterfaceModelsTab.js
@@ -330,7 +330,7 @@ class InterfaceModelsTab extends Component {
         this.state.interfaceModel);
     }
     this.props.updateGlobalState('model', model);
-    this.setState({overallMode: MODE.NONE});
+    this.closeModelDetails();
   }
 
 

--- a/src/pages/ServerRoleSummary/NetworksTab.js
+++ b/src/pages/ServerRoleSummary/NetworksTab.js
@@ -96,10 +96,10 @@ class NetworksTab extends Component {
         <UpdateNetworks ref={'updateNetwork' + this.state.mode}
           model={this.props.model} mode={this.state.mode} {...extraProps}
           updateGlobalState={this.props.updateGlobalState}
+          setDataChanged={this.props.setDataChanged}
           closeAction={this.handleCancelUpdateNetwork}/>
       </div>
     );
-
   }
 
   renderNetworkTable() {

--- a/src/pages/ServerRoleSummary/NicMappingTab.js
+++ b/src/pages/ServerRoleSummary/NicMappingTab.js
@@ -189,7 +189,7 @@ class NicMappingTab extends Component {
 
   saveDetails = () => {
     this.props.updateGlobalState('model', this.getUpdatedModel());
-    this.setState({mode: MODE.NONE});
+    this.closeDetails();
   }
 
   renderDetailRows() {

--- a/src/pages/ServerRoleSummary/NicMappingTab.js
+++ b/src/pages/ServerRoleSummary/NicMappingTab.js
@@ -101,20 +101,26 @@ class NicMappingTab extends Component {
   }
 
   isSaveAllowed = () => {
+    let isChanged = undefined;
+
     // The save button is allowed if the values are all valid and there is
     // some change compared to the initial values
 
     const isValid = this.state.isNameValid && this.state.detailRows.every(e =>
       e.get('isBusAddressValid') && e.get('isLogicalNameValid'));
-    if (!isValid)
-      return false;
-
-    // If we are in add mode, then something has changed, so return true
-    if (this.state.mode === MODE.ADD)
-      return true;
-
-    return this.getSortedModel().getIn(['inputModel', 'nic-mappings', this.state.activeRow])
-      !== this.getUpdatedModel().getIn(['inputModel', 'nic-mappings', this.state.activeRow]);
+    if (!isValid) {
+      isChanged = false;
+    } else {
+      // If we are in add mode, then something has changed, so return true
+      if (this.state.mode === MODE.ADD) {
+        isChanged = true;
+      } else {
+        isChanged = this.getSortedModel().getIn(['inputModel', 'nic-mappings', this.state.activeRow])
+          !== this.getUpdatedModel().getIn(['inputModel', 'nic-mappings', this.state.activeRow]);
+      }
+    }
+    this.props.setDataChanged(0, isChanged);
+    return isChanged;
   }
 
   newDetailRow = () => Map({
@@ -225,6 +231,11 @@ class NicMappingTab extends Component {
     });
   }
 
+  closeDetails = () => {
+    this.props.setDataChanged(0, false);
+    this.setState({mode: MODE.NONE});
+  }
+
   renderDetails = () => {
 
     if (this.state.mode !== MODE.NONE) {
@@ -257,7 +268,7 @@ class NicMappingTab extends Component {
                 <div className='btn-container'>
 
                   <ActionButton key='cancel' type='default'
-                    clickAction={(e) => this.setState({mode: MODE.NONE})}
+                    clickAction={this.closeDetails}
                     displayLabel={translate('cancel')}/>
 
                   <ActionButton key='save' clickAction={this.saveDetails}

--- a/src/pages/ServerRoleSummary/ServerGroupDetails.js
+++ b/src/pages/ServerRoleSummary/ServerGroupDetails.js
@@ -85,19 +85,27 @@ class ServerGroupDetails extends Component {
   }
 
   checkDataToSave = () => {
+    let dataChanged = undefined;
     if (this.props.value === '') {
-      return this.state.name !== '';
+      dataChanged = this.state.name !== '';
     } else {
       let newNetworks = this.state.networks.slice().sort();
       let newServerGroups = this.state.serverGroups.slice().sort();
       if ((this.state.name !== '' && this.state.name !== this.origName) ||
         ((JSON.stringify(newNetworks) !== JSON.stringify(this.origNetworks)) ||
          (JSON.stringify(newServerGroups) !== JSON.stringify(this.origServerGroups)))) {
-        return true;
+        dataChanged = true;
       } else {
-        return false;
+        dataChanged = false;
       }
     }
+    this.props.setDataChanged(1, dataChanged);
+    return dataChanged;
+  }
+
+  closeAction = () => {
+    this.props.setDataChanged(1, false);
+    this.props.closeAction();
   }
 
   render() {
@@ -145,7 +153,7 @@ class ServerGroupDetails extends Component {
               sendSelectedList={this.getSelectedServerGroups} exceptions={exceptions}/>
             <div className='btn-row details-btn'>
               <div className='btn-container'>
-                <ActionButton key='cancel' type='default' clickAction={this.props.closeAction}
+                <ActionButton key='cancel' type='default' clickAction={this.closeAction}
                   displayLabel={translate('cancel')}/>
                 <ActionButton key='save' clickAction={this.saveServerGroup}
                   displayLabel={translate('save')} isDisabled={!this.checkDataToSave()}/>

--- a/src/pages/ServerRoleSummary/ServerGroupDetails.js
+++ b/src/pages/ServerRoleSummary/ServerGroupDetails.js
@@ -81,7 +81,7 @@ class ServerGroupDetails extends Component {
       }
     }
     this.props.updateGlobalState('model', model);
-    this.props.closeAction();
+    this.closeAction();
   }
 
   checkDataToSave = () => {

--- a/src/pages/ServerRoleSummary/ServerGroupsTab.js
+++ b/src/pages/ServerRoleSummary/ServerGroupsTab.js
@@ -120,7 +120,7 @@ class ServerGroupsTab extends Component {
     if (this.state.showServerGroupDetails) {
       detailsSection = (<ServerGroupDetails model={this.props.model}
         value={this.state.value} updateGlobalState={this.props.updateGlobalState}
-        closeAction={this.hideServerGroupDetails}/>);
+        setDataChanged={this.props.setDataChanged} closeAction={this.hideServerGroupDetails}/>);
     }
 
     let confirmRemoveSection = '';

--- a/src/pages/ServerRoleSummary/UpdateNetworks.js
+++ b/src/pages/ServerRoleSummary/UpdateNetworks.js
@@ -169,7 +169,7 @@ class UpdateNetworks extends Component {
         net => net.splice(idx, 1, fromJS(this.state.data)));
       this.props.updateGlobalState('model', model);
     }
-    this.props.closeAction();
+    this.closeAction();
   }
 
   handleTaggedVLANChange = () => {
@@ -310,18 +310,9 @@ class UpdateNetworks extends Component {
   }
 
   checkDataToSave = () => {
-    let dataChanged = undefined;
-    if (!this.state.isFormValid) {
-      dataChanged = false;
-    } else {
-      if (JSON.stringify(this.origData) !== JSON.stringify(this.state.data)) {
-        dataChanged = true;
-      } else {
-        dataChanged = false;
-      }
-    }
+    const dataChanged = JSON.stringify(this.origData) !== JSON.stringify(this.state.data);
     this.props.setDataChanged(2, dataChanged);
-    return dataChanged;
+    return this.state.isFormValid && dataChanged;
   }
 
   closeAction = () => {

--- a/src/pages/ServerRoleSummary/UpdateNetworks.js
+++ b/src/pages/ServerRoleSummary/UpdateNetworks.js
@@ -28,7 +28,6 @@ class UpdateNetworks extends Component {
   constructor(props) {
     super(props);
     this.networkGroups = this.getNetworkGroups();
-    this.data = this.props.mode === MODE.EDIT ? this.getNetworkData(this.props.networkName) : {};
     this.allInputsStatus = {
       'name': INPUT_STATUS.UNKNOWN,
       'vlanid': INPUT_STATUS.UNKNOWN,
@@ -38,18 +37,21 @@ class UpdateNetworks extends Component {
 
     this.allAddressesStatus = [];
 
+    let networks = this.props.mode === MODE.EDIT ? this.getNetworkData(this.props.networkName) : {};
+    networks.addresses = this.initAddresses(networks);
     this.state = {
       isFormValid: false,
-      isFormChanged: false,
-      addresses: this.initAddresses(),
-      isTaggedChecked:
-        this.data['tagged-vlan'] !== '' && this.data['tagged-vlan'] !== undefined ?  this.data['tagged-vlan'] : false,
+      data: networks,
     };
+
+    if (this.props.mode === MODE.EDIT) {
+      this.origData = networks;
+    }
   }
 
-  initAddresses() {
+  initAddresses(networks) {
     // for UI state addresses
-    let retAddresses = this.data['addresses'] ? this.data['addresses'] : [];
+    let retAddresses = networks['addresses'] ? networks['addresses'] : [];
 
     // init validation status
     this.allAddressesStatus = retAddresses.map((addr) => {
@@ -81,7 +83,7 @@ class UpdateNetworks extends Component {
 
   isFormDropdownValid() {
     let isValid = true;
-    if(this.data['network-group'] === '' || this.data['network-group'] === undefined) {
+    if(this.state.data['network-group'] === '' || this.state.data['network-group'] === undefined) {
       isValid = false;
     }
     return isValid;
@@ -93,93 +95,89 @@ class UpdateNetworks extends Component {
   }
 
   handleSelectNetworkGroup = (groupName) => {
-    this.data['network-group'] = groupName;
-    if(!this.state.isFormChanged) {
-      this.setState({isFormChanged: true});
-    }
-    this.setState({isFormValid: this.isFormTextInputValid() && this.isFormDropdownValid()});
+    this.setState(prevState => {
+      const newData = JSON.parse(JSON.stringify(prevState.data));
+      newData['network-group'] = groupName;
+      return {
+        data: newData,
+        isFormValid: this.isFormTextInputValid() && this.isFormDropdownValid()
+      };
+    });
   }
 
   handleInputChange = (e, isValid, props) => {
     let value = e.target.value;
     this.updateFormValidity(props, isValid);
     if (isValid) {
-      if(!this.state.isFormChanged) {
-        this.setState({isFormChanged: true});
-      }
       if(props.inputName === 'vlanid') {
         value = parseInt(value);
       }
 
-      this.data[props.inputName] = value;
+      this.setState(prevState => {
+        const newData = JSON.parse(JSON.stringify(prevState.data));
+        newData[props.inputName] = value;
+        return {data: newData};
+      });
     }
   }
 
   handleAddressChange = (e, isValid, props, idx) => {
     let value = e.target.value;
     if (isValid) {
-      if(!this.state.isFormChanged) {
-        this.setState({isFormChanged: true});
-      }
       this.allAddressesStatus[idx] = INPUT_STATUS.VALID;
 
-      // this.data is the final result to be saved into model, init if we don't have any
-      // addresses will be processed when save later
-      if(!this.data['addresses']) {
-        this.data['addresses'] = [];
-      }
+      this.setState(prevState => {
+        const newData = JSON.parse(JSON.stringify(prevState.data));
+        newData.addresses[idx] = value;
+        return {data: newData};
+      });
     }
     else {
       this.allAddressesStatus[idx] = INPUT_STATUS.INVALID;
     }
 
-    this.setState(prev => {
-      let addresses = prev.addresses.slice();
-      addresses[idx] = value;
-      return {addresses: addresses};
-    });
     this.updateFormValidity(props, isValid);
   }
 
   handleUpdateNetwork = () => {
     let model = this.props.model;
-    for (let key in this.data) {
-      if(this.data[key] === undefined || this.data[key] === '') {
-        delete this.data[key];
+    for (let key in this.state.data) {
+      if(this.state.data[key] === undefined || this.state.data[key] === '') {
+        delete this.state.data[key];
       }
 
       if (key === 'addresses') {
-        let cleanAddrs = this.state.addresses.filter(addr => addr !== '');
+        let cleanAddrs = this.state.data.addresses.filter(addr => addr !== '');
         if (cleanAddrs.length === 0) {
-          delete this.data[key];
+          delete this.state.data[key];
         }
         else {
-          this.data[key] = cleanAddrs;
+          this.state.data[key] = cleanAddrs;
         }
       }
     }
 
     if(this.props.mode === MODE.ADD) {
       model = model.updateIn(
-        ['inputModel', 'networks'], net => net.push(fromJS(this.data)));
+        ['inputModel', 'networks'], net => net.push(fromJS(this.state.data)));
       this.props.updateGlobalState('model', model);
     }
     else {
       let idx = model.getIn(['inputModel','networks']).findIndex(
         net => net.get('name') === this.props.networkName);
       model = model.updateIn(['inputModel', 'networks'],
-        net => net.splice(idx, 1, fromJS(this.data)));
+        net => net.splice(idx, 1, fromJS(this.state.data)));
       this.props.updateGlobalState('model', model);
     }
     this.props.closeAction();
   }
 
   handleTaggedVLANChange = () => {
-    this.data['tagged-vlan'] = !this.state.isTaggedChecked;
-    if(!this.state.isFormChanged) {
-      this.setState({isFormChanged: true});
-    }
-    this.setState({isTaggedChecked: !this.state.isTaggedChecked});
+    this.setState(prevState => {
+      const newData = JSON.parse(JSON.stringify(prevState.data));
+      newData['tagged-vlan'] = !prevState.data['tagged-vlan'];
+      return {data: newData};
+    });
   }
 
   getNetworkGroups = () => {
@@ -189,20 +187,20 @@ class UpdateNetworks extends Component {
   }
 
   removeAddress = (idx) => {
-    this.setState(prev => {
-      let addresses = prev.addresses.slice();
-      addresses.splice(idx, 1);
-      return {addresses: addresses, isFormChanged: true};
+    this.setState(prevState => {
+      const newData = JSON.parse(JSON.stringify(prevState.data));
+      newData.addresses.splice(idx, 1);
+      return {data: newData};
     });
     // remove status
     this.allAddressesStatus.splice(idx, 1);
   }
 
   addAddress = () => {
-    this.setState(prev => {
-      let addresses = prev.addresses.slice();
-      addresses.push(''); //empty input
-      return {addresses: addresses};
+    this.setState(prevState => {
+      const newData = JSON.parse(JSON.stringify(prevState.data));
+      newData.addresses.push('');
+      return {data: newData};
     });
   }
 
@@ -220,11 +218,11 @@ class UpdateNetworks extends Component {
   }
 
   renderNetworkAddresses () {
-    if(this.state.addresses.length === 0) {
+    if(this.state.data.addresses.length === 0) {
       return this.renderNewAddressInput();
     }
-    let addressRows = this.state.addresses.map((addr, idx) => {
-      const lastRow = (idx === this.state.addresses.length -1);
+    let addressRows = this.state.data.addresses.map((addr, idx) => {
+      const lastRow = (idx === this.state.data.addresses.length -1);
       return (
         <div key={idx} className='dropdown-plus-minus'>
           <div className="field-container">
@@ -279,35 +277,58 @@ class UpdateNetworks extends Component {
       <ServerInputLine
         isRequired={isRequired} inputName={name} inputType={type}
         placeholder={placeholderText} inputValidate={validate}
-        inputValue={this.props.mode === MODE.EDIT ? this.data[name] : ''} {...extraProps}
+        inputValue={this.props.mode === MODE.EDIT ? this.state.data[name] : ''} {...extraProps}
         inputAction={this.handleInputChange}/>
     );
   }
 
   renderNetworkGroup() {
     let emptyOptProps = '';
-    if(this.data['network-group'] === '' || this.data['network-group'] === undefined) {
+    if(this.state.data['network-group'] === '' || this.state.data['network-group'] === undefined) {
       emptyOptProps = {
         label: translate('network.group.please.select'),
         value: 'noopt'
       };
     }
     return (
-      <ServerDropdownLine value={this.data['network-group']}
+      <ServerDropdownLine value={this.state.data['network-group']}
         optionList={this.networkGroups} isRequired={true}
         emptyOption={emptyOptProps} selectAction={this.handleSelectNetworkGroup}/>
     );
   }
 
   renderTaggedVLAN() {
+    const checked = this.state.data['tagged-vlan'] !== '' && this.state.data['tagged-vlan'] !== undefined ?
+      this.state.data['tagged-vlan'] : false;
     return (
       <div className='tagged-vlan'>
         <input className='tagged' type='checkbox' value='taggedvlan'
-          checked={this.state.isTaggedChecked} onChange={this.handleTaggedVLANChange}/>
+          checked={checked} onChange={this.handleTaggedVLANChange}/>
         {translate('tagged-vlan')}
       </div>
     );
   }
+
+  checkDataToSave = () => {
+    let dataChanged = undefined;
+    if (!this.state.isFormValid) {
+      dataChanged = false;
+    } else {
+      if (JSON.stringify(this.origData) !== JSON.stringify(this.state.data)) {
+        dataChanged = true;
+      } else {
+        dataChanged = false;
+      }
+    }
+    this.props.setDataChanged(2, dataChanged);
+    return dataChanged;
+  }
+
+  closeAction = () => {
+    this.props.setDataChanged(2, false);
+    this.props.closeAction();
+  }
+
   render() {
     let title =
       this.props.mode === MODE.EDIT ? translate('network.update') : translate('network.add');
@@ -332,10 +353,10 @@ class UpdateNetworks extends Component {
           {this.renderTaggedVLAN()}
           <div className='btn-row details-btn network-more-width'>
             <div className='btn-container'>
-              <ActionButton key='networkCancel' type='default' clickAction={this.props.closeAction}
+              <ActionButton key='networkCancel' type='default' clickAction={this.closeAction}
                 displayLabel={translate('cancel')}/>
               <ActionButton key='networkSave' clickAction={this.handleUpdateNetwork}
-                displayLabel={translate('save')} isDisabled={!this.state.isFormValid || !this.state.isFormChanged}/>
+                displayLabel={translate('save')} isDisabled={!this.checkDataToSave()}/>
             </div>
           </div>
         </div>

--- a/src/styles/pages/ServerRoleSummary.less
+++ b/src/styles/pages/ServerRoleSummary.less
@@ -202,8 +202,6 @@
       display: inline-flex;
     }
     .network-table-container {
-      min-height: 30em;
-      max-height: 40em;
       overflow: auto;
       display: inline-flex;
     }


### PR DESCRIPTION
SCRD-1950 Add a confirmation modal before exiting the Manage Cloud Settings modal when detecting changes to any of the tabs so that the user won't lose the changes accidentally. 

Also fix the logic to detect changes in the Networks tab which didn't compare the new value with the original value which caused the tab to report a change even when the new value and the original value are the same.

The change in ServerRoleSummary.js is an enhancement to expand the first group when there's no COMPUTE-ROLE group. An example of this case can be seen when you selected Entry Scale Ironic Multi-tenant Network. 

