### PR TITLE
Facilitate OBS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,23 @@ To run the application from that location, together with a local copy of the ard
 
 Note!  
 You will need an appropriate ardana-service backend to provide data model information. A link to that repo will be put here if/when it becomes public  
+
+# Open Build Service (OBS)
+In order to build with OBS, a tarball containing the contents of the node_modules must be created
+and added to the package.  Create a clean node_modules directory with either:
+```
+yarn install --link-duplicates
+```
+
+or:
+
+```
+rm -rf node_modules
+npm install
+```
+
+and then create the tarball with:
+
+```
+tar cjf node_modules.tar.bz2 node_modules
+```

--- a/build_dist.sh
+++ b/build_dist.sh
@@ -18,6 +18,9 @@ die() {
    exit 1
 }
 
+# install npm dependencies to run the build
+npm install
+
 # build the neccessary UI files
 ./build_ui.sh || die "building UI files failed, exiting"
 

--- a/build_ui.sh
+++ b/build_ui.sh
@@ -18,9 +18,6 @@ die() {
    exit 1
 }
 
-# install npm dependencies to run the build
-npm install
-
 TARBALL=false
 
 # if -t is specified, build a tarball of the UI bits
@@ -63,11 +60,11 @@ mkdir -p dist/lib/fonts
 cp third_party/fonts/* dist/lib/fonts
 cp node_modules/material-design-icons-iconfont/dist/fonts/* dist/lib/fonts
 
-#create a version variable using the commit hash
-SHA=$(git rev-parse HEAD | cut -c1-6)
-
 if $TARBALL
 then
+  #create a version variable using the commit hash
+  SHA=$(git rev-parse HEAD | cut -c1-6)
+
   #create a tarball of the UI dist
   cd dist
   tar -czvf ../cloudinstaller-webonly-${SHA}.tgz .


### PR DESCRIPTION
Juggle the npm install around so that build_ui.sh can be called directly
in the OBS .spec file to perform a build.  Update README for
instructions on building the node modules tarball.