### PR TITLE
Add ability to add new nic mappings or server groups from Edit Server Details modal

### DIFF
--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -41,6 +41,7 @@ class ActionButton extends Component {
     let buttonClass = 'btn ' + (this.props.type ? 'btn-' + this.props.type + ' ' : 'btn-primary ') +
       (this.props.isDisabled ? ' disabled' : '');
     buttonClass += (this.props.lastButton) ? 'last-button' : '';
+    buttonClass += (this.props.moreClass) ? 'inline-button' : '';
     return (
       <button
         className={buttonClass}

--- a/src/components/ServerUtils.js
+++ b/src/components/ServerUtils.js
@@ -265,9 +265,14 @@ export class ServerInput extends Component {
       }
     }
 
+    let classname = 'server-input';
+    if (this.props.moreClass) {
+      classname += ' ' + this.props.moreClass;
+    }
+
     if (this.props.inputType === 'textarea') {
       return (
-        <div className='server-input'>
+        <div className={classname}>
           <textarea
             id={this.props.id}
             className='rounded-corner'
@@ -284,7 +289,7 @@ export class ServerInput extends Component {
       );
     } else {
       return (
-        <div className='server-input'>
+        <div className={classname}>
           <input
             id={this.props.id}
             className='rounded-corner'
@@ -316,7 +321,8 @@ export class ServerInputLine extends Component {
           <ServerInput isRequired={this.props.isRequired} inputName={this.props.inputName}
             inputType={this.props.inputType} inputValidate={this.props.inputValidate} {... this.props}
             inputAction={this.props.inputAction} inputValue={this.props.inputValue}
-            updateFormValidity={this.props.updateFormValidity} category={this.props.category}/>
+            updateFormValidity={this.props.updateFormValidity} category={this.props.category}
+            moreClass={this.props.moreClass}/>
         </div>
       </div>
     );
@@ -366,8 +372,12 @@ export class ServerDropdown extends Component {
   }
 
   render() {
+    let classname = 'server-detail-select';
+    if (this.props.moreClass) {
+      classname += ' ' + this.props.moreClass;
+    }
     return (
-      <div className="server-detail-select">
+      <div className={classname}>
         <select className='rounded-corner' value={this.state.value} name={this.props.name}
           onChange={this.handleSelect}>{this.renderOptions()}</select>
       </div>
@@ -385,7 +395,8 @@ export class ServerDropdownLine extends Component {
         <div className='input-body'>
           <ServerDropdown name={this.props.name} value={this.props.value}
             optionList={this.props.optionList} emptyOption={this.props.emptyOption}
-            selectAction={this.props.selectAction} defaultOption={this.props.defaultOption}/>
+            selectAction={this.props.selectAction} defaultOption={this.props.defaultOption}
+            moreClass={this.props.moreClass}/>
         </div>
       </div>
     );

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -1290,7 +1290,8 @@ class AssignServerRoles extends BaseWizardPage {
         <EditServerDetails
           cancelAction={this.handleCancelEditServer}
           doneAction={this.handleDoneEditServer}
-          serverGroups={getServerGroups(this.props.model)} nicMappings={getNicMappings(this.props.model)}
+          model={this.props.model}
+          updateGlobalState={this.props.updateGlobalState}
           data={this.state.activeRowData}>
         </EditServerDetails>
       </BaseInputModal>
@@ -1306,7 +1307,7 @@ class AssignServerRoles extends BaseWizardPage {
           </div>
           <div className='buttonBox'>
             <div className='btn-row'>
-              <ActionButton displayLabel={translate('add.server.set.network')}
+              <ActionButton displayLabel={translate('add.server.set.network')} type='default'
                 clickAction={() => this.setState({showBaremetalSettings: true})}/>
             </div>
           </div>

--- a/src/pages/ServerRoleSummary.js
+++ b/src/pages/ServerRoleSummary.js
@@ -91,7 +91,8 @@ class ServerRoleSummary extends BaseWizardPage {
       <CollapsibleTable
         addExpandedGroup={this.addExpandedGroup} removeExpandedGroup={this.removeExpandedGroup}
         model={this.props.model} tableConfig={tableConfig} expandedGroup={this.state.expandedGroup}
-        saveEditServer={this.saveEditServer} checkInputs={this.checkInputs}/>
+        saveEditServer={this.saveEditServer} checkInputs={this.checkInputs}
+        updateGlobalState={this.props.updateGlobalState}/>
     );
   }
 
@@ -109,7 +110,7 @@ class ServerRoleSummary extends BaseWizardPage {
           </div>
           <div className='buttonBox'>
             <div className='btn-row'>
-              <ActionButton displayLabel={translate('edit.cloud.settings')}
+              <ActionButton displayLabel={translate('edit.cloud.settings')} type='default'
                 clickAction={() => this.setState({showCloudSettings: true})} />
               <ActionButton type='default'
                 displayLabel={translate('collapse.all')} clickAction={() => this.collapseAll()} />

--- a/src/pages/ServerRoleSummary/CollapsibleTable.js
+++ b/src/pages/ServerRoleSummary/CollapsibleTable.js
@@ -16,7 +16,6 @@ import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import EditServerDetails from '../../components/EditServerDetails.js';
 import ViewServerDetails from '../AssignServerRoles/ViewServerDetails.js';
-import { getNicMappings, getServerGroups } from '../../utils/ModelUtils.js';
 import { BaseInputModal } from '../../components/Modals.js';
 import { List, Map } from 'immutable';
 import { byServerNameOrId } from '../../utils/Sort.js';
@@ -187,7 +186,7 @@ class CollapsibleTable extends Component {
         onHide={this.handleCancelEditServer} title={translate('edit.server.details.heading')}>
         <EditServerDetails
           cancelAction={this.handleCancelEditServer} doneAction={this.handleDoneEditServer}
-          serverGroups={getServerGroups(this.state.model)} nicMappings={getNicMappings(this.state.model)}
+          model={this.props.model} updateGlobalState={this.props.updateGlobalState}
           data={this.state.activeRowData}>
         </EditServerDetails>
       </BaseInputModal>

--- a/src/pages/ServerRoleSummary/EditCloudSettings.js
+++ b/src/pages/ServerRoleSummary/EditCloudSettings.js
@@ -59,35 +59,59 @@ class EditCloudSettings extends Component {
   }
 
   render() {
-    let cloudSettings;
+    let tabs;
     if (this.props.oneTab) {
       if (this.props.oneTab === 'server-group') {
-        cloudSettings = (
-          <ConfirmModal show={this.props.show} title={translate('edit.cloud.settings')}
-            className={'cloud-settings'} hideFooter='true' onHide={this.props.onHide}>
-            <Tabs id='editCloudSettings' activeKey={TAB.SERVER_GROUPS}
-              onSelect={(tabKey) => {this.setState({key: tabKey});}}>
-              <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
-                <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}/>
-              </Tab>
-            </Tabs>
-          </ConfirmModal>
+        tabs = (
+          <Tabs id='editCloudSettings' activeKey={TAB.SERVER_GROUPS}
+            onSelect={(tabKey) => {this.setState({key: tabKey});}}>
+            <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
+              <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+                setDataChanged={this.setDataChanged}/>
+            </Tab>
+          </Tabs>
         );
       } else {
-        cloudSettings = (
-          <ConfirmModal show={this.props.show} title={translate('edit.cloud.settings')}
-            className={'cloud-settings'} hideFooter='true' onHide={this.props.onHide}>
-            <Tabs id='editCloudSettings' activeKey={TAB.NIC_MAPPINGS}
-              onSelect={(tabKey) => {this.setState({key: tabKey});}}>
-              <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
-                <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}/>
-              </Tab>
-            </Tabs>
-          </ConfirmModal>
+        tabs = (
+          <Tabs id='editCloudSettings' activeKey={TAB.NIC_MAPPINGS}
+            onSelect={(tabKey) => {this.setState({key: tabKey});}}>
+            <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
+              <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+                setDataChanged={this.setDataChanged}/>
+            </Tab>
+          </Tabs>
         );
       }
     } else {
-      cloudSettings = (
+      tabs = (
+        <Tabs id='editCloudSettings' activeKey={this.state.key}
+          onSelect={(tabKey) => {this.setState({key: tabKey});}}>
+          <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
+            <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+              setDataChanged={this.setDataChanged}/>
+          </Tab>
+          <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
+            <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+              setDataChanged={this.setDataChanged}/>
+          </Tab>
+          <Tab eventKey={TAB.NETWORKS} title={translate('edit.networks')}>
+            <NetworksTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+              setDataChanged={this.setDataChanged}/>
+          </Tab>
+          <Tab eventKey={TAB.DISK_MODELS} title={translate('edit.disk.models')}>
+            <DiskModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+              setDataChanged={this.setDataChanged}/>
+          </Tab>
+          <Tab eventKey={TAB.INTERFACE_MODELS} title={translate('edit.interface.models')}>
+            <InterfaceModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+              setDataChanged={this.setDataChanged}/>
+          </Tab>
+        </Tabs>
+      );
+    }
+
+    return (
+      <div>
         <ConfirmModal
           show={this.props.show}
           title={translate('edit.cloud.settings')}
@@ -95,37 +119,9 @@ class EditCloudSettings extends Component {
           hideFooter='true'
           onHide={this.showConfirmCloseModal}>
 
-          <Tabs id='editCloudSettings' activeKey={this.state.key}
-            onSelect={(tabKey) => {this.setState({key: tabKey});}}>
-            <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
-              <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-                setDataChanged={this.setDataChanged}/>
-            </Tab>
-            <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
-              <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-                setDataChanged={this.setDataChanged}/>
-            </Tab>
-            <Tab eventKey={TAB.NETWORKS} title={translate('edit.networks')}>
-              <NetworksTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-                setDataChanged={this.setDataChanged}/>
-            </Tab>
-            <Tab eventKey={TAB.DISK_MODELS} title={translate('edit.disk.models')}>
-              <DiskModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-                setDataChanged={this.setDataChanged}/>
-            </Tab>
-            <Tab eventKey={TAB.INTERFACE_MODELS} title={translate('edit.interface.models')}>
-              <InterfaceModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-                setDataChanged={this.setDataChanged}/>
-            </Tab>
-          </Tabs>
+          {tabs}
 
         </ConfirmModal>
-      );
-    }
-
-    return (
-      <div>
-        {cloudSettings}
 
         <YesNoModal show={this.state.showCloseConfirmation} title={translate('warning')}
           yesAction={this.closeModals} noAction={() => this.setState({showCloseConfirmation: false})}>

--- a/src/pages/ServerRoleSummary/EditCloudSettings.js
+++ b/src/pages/ServerRoleSummary/EditCloudSettings.js
@@ -59,8 +59,35 @@ class EditCloudSettings extends Component {
   }
 
   render() {
-    return (
-      <div>
+    let cloudSettings;
+    if (this.props.oneTab) {
+      if (this.props.oneTab === 'server-group') {
+        cloudSettings = (
+          <ConfirmModal show={this.props.show} title={translate('edit.cloud.settings')}
+            className={'cloud-settings'} hideFooter='true' onHide={this.props.onHide}>
+            <Tabs id='editCloudSettings' activeKey={TAB.SERVER_GROUPS}
+              onSelect={(tabKey) => {this.setState({key: tabKey});}}>
+              <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
+                <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}/>
+              </Tab>
+            </Tabs>
+          </ConfirmModal>
+        );
+      } else {
+        cloudSettings = (
+          <ConfirmModal show={this.props.show} title={translate('edit.cloud.settings')}
+            className={'cloud-settings'} hideFooter='true' onHide={this.props.onHide}>
+            <Tabs id='editCloudSettings' activeKey={TAB.NIC_MAPPINGS}
+              onSelect={(tabKey) => {this.setState({key: tabKey});}}>
+              <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
+                <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}/>
+              </Tab>
+            </Tabs>
+          </ConfirmModal>
+        );
+      }
+    } else {
+      cloudSettings = (
         <ConfirmModal
           show={this.props.show}
           title={translate('edit.cloud.settings')}
@@ -93,6 +120,12 @@ class EditCloudSettings extends Component {
           </Tabs>
 
         </ConfirmModal>
+      );
+    }
+
+    return (
+      <div>
+        {cloudSettings}
 
         <YesNoModal show={this.state.showCloseConfirmation} title={translate('warning')}
           yesAction={this.closeModals} noAction={() => this.setState({showCloseConfirmation: false})}>

--- a/src/styles/components/buttons.less
+++ b/src/styles/components/buttons.less
@@ -83,6 +83,15 @@
   }
 }
 
+.inline-button {
+  float: right;
+  margin-left: 1em;
+  font-size: 13px;
+  height: 28px;
+  line-height: 13px;
+  width: 120px;
+}
+
 .card {
   color: @preferredcolor;
   padding: 15px;

--- a/src/styles/components/serverutils.less
+++ b/src/styles/components/serverutils.less
@@ -117,6 +117,18 @@
     padding: 4px;
     width: 80%;
   }
+  .server-detail-select.has-button {
+    width: 70%;
+  }
+
+  .server-detail-select.has-button select {
+    width: 100%;
+  }
+
+  .input-with-button {
+    display: flex;
+    width: 100%;
+  }
 
   &.viewonly {
     margin-top: 4em;
@@ -138,6 +150,10 @@
     color:@errorcolor;
     display: block;
   }
+}
+
+.server-input.has-button input {
+  width: 70%;
 }
 
 .server-input input {


### PR DESCRIPTION
SCRD-2394 Add two new buttons to the Edit Server Details modal to allow the user to add new nic mappings or server groups. The buttons launch the Manage Cloud Setting modal with only one tab, either the Nic Mappings tab or the Server Groups tab.

Also change the Manage Cloud Settings and the Manage Subnet and Netmask buttons to be just default buttons (gray color).