### PR TITLE
Fixed input with plus and minuse overwritten issue

### DIFF
--- a/src/pages/ServerRoleSummary/UpdateNetworks.js
+++ b/src/pages/ServerRoleSummary/UpdateNetworks.js
@@ -206,7 +206,7 @@ class UpdateNetworks extends Component {
 
   renderNewAddressInput () {
     return (
-      <div key={0} className='dropdown-plus-minus'>
+      <div key={0} className='dropdown-plus-minus network-plus-minus'>
         <div className="field-container">
           <ServerInput
             inputAction={(e, valid, props) => this.handleAddressChange(e, valid, props, 0)}
@@ -224,7 +224,7 @@ class UpdateNetworks extends Component {
     let addressRows = this.state.data.addresses.map((addr, idx) => {
       const lastRow = (idx === this.state.data.addresses.length -1);
       return (
-        <div key={idx} className='dropdown-plus-minus'>
+        <div key={idx} className='dropdown-plus-minus network-plus-minus'>
           <div className="field-container">
             <ServerInput
               inputAction={(e, valid, props) => this.handleAddressChange(e, valid, props, idx)}

--- a/src/styles/pages/ServerRoleSummary.less
+++ b/src/styles/pages/ServerRoleSummary.less
@@ -122,8 +122,10 @@
         }
       }
 
-      .network-section, .detail-line, .server-input {
-         width: 100%;
+      &.network-plus-minus {
+        .server-input {
+          width: 100%;
+        }
         input {
           width: 100%;
         }


### PR DESCRIPTION
This checkin fixed the issue where network addresses input plus/minuse
styling 100% overwrote styling 85% in other places for example, in Disk
Models tab, Add Volume Group when add physical volumes.