### PR TITLE
Add ability to edit NTP and DNS settings

### DIFF
--- a/src/components/InlineAddRemoveFields.js
+++ b/src/components/InlineAddRemoveFields.js
@@ -198,6 +198,7 @@ class InlineAddRemoveInput extends Component {
       if (nextState.selectedItem !== this.state.selectedItem) {
         let sentItems = nextState.items.slice();
         sentItems.splice(nextState.items.length - 1, 1, nextState.selectedItem);
+        this.setState({items: sentItems});
         this.props.sendSelectedList(sentItems);
       }
     } else {
@@ -227,11 +228,9 @@ class InlineAddRemoveInput extends Component {
   addItem = () => {
     if (!this.props.disabled) {
       this.setState(prevState => {
-        if (prevState.selectedItem !== '') {
-          let newItems = prevState.items.slice();
-          newItems.splice(newItems.length - 1, 0, prevState.selectedItem);
-          return {items: newItems, selectedItem: ''};
-        }
+        let newItems = prevState.items.slice();
+        newItems.splice(newItems.length, 0, '');
+        return {items: newItems, selectedItem: ''};
       });
     }
   }
@@ -283,6 +282,7 @@ class InlineAddRemoveInput extends Component {
         </div>
       );
     });
+    const required = this.props.isRequired ? this.props.isRequired : 'true';
 
     return (
       <div>
@@ -290,7 +290,7 @@ class InlineAddRemoveInput extends Component {
         <div className='dropdown-plus-minus'>
           <ServerInput key={this.props.name + 'start'} inputValue={this.state.selectedItem}
             inputType='text' inputAction={this.handleInputLine} placeholder={this.props.placeholder}
-            isRequired='true' disabled={this.props.disabled}/>
+            isRequired={required} disabled={this.props.disabled}/>
           <div className='plus-minus-container'>
             <span key={this.props.name + 'minus'} className={selectedRemoveClass}
               onClick={() => this.removeItem(-1)}/>

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -216,6 +216,7 @@
 
     "edit.cloud.settings": "Manage Cloud Settings",
     "edit.cloud.settings.close.confirm": "You've selected to leave Manage Cloud Settings but you have unsaved changes. \n\n Are you sure you want to proceed?",
+    "edit.cloud.config": "Cloud Configuration",
     "edit.nic.mappings": "NIC Mappings",
     "edit.server.groups": "Server Groups",
     "edit.networks": "Networks",
@@ -235,6 +236,12 @@
     "network.gateway": "Gateway IP",
     "network": "Network",
     "network.addresses": "Addresses",
+    "config.ntp": "NTP Servers",
+    "config.ntp.placeholder": "NTP Server Name or IP Address",
+    "config.dns": "DNS Name Servers",
+    "config.dns.placeholder": "Name Server IP Address",
+    "config.host.name.prefix": "Host Name Prefix",
+    "config.host.member.prefix": "Host Member Prefix",
 
     "vlanid": "VLAN ID",
     "cidr": "CIDR",

--- a/src/pages/ServerRoleSummary/CloudConfigTab.js
+++ b/src/pages/ServerRoleSummary/CloudConfigTab.js
@@ -1,0 +1,168 @@
+// (c) Copyright 2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+import React, { Component } from 'react';
+import { fromJS } from 'immutable';
+import { translate } from '../../localization/localize.js';
+import { InlineAddRemoveInput } from '../../components/InlineAddRemoveFields.js';
+import { ServerInput } from '../../components/ServerUtils.js';
+import { ActionButton } from '../../components/Buttons.js';
+
+class CloudConfigTab extends Component {
+
+  constructor(props) {
+    super(props);
+    const ntpList = props.model.getIn(['inputModel','cloud', 'ntp-servers']);
+    this.origNTP = (ntpList === null) ? [] : ntpList.toJS();
+    const dnsList = props.model.getIn(['inputModel','cloud', 'dns-settings']);
+    this.origDNS = (dnsList === null) ? [] : dnsList.toJS().nameservers ? dnsList.toJS().nameservers : [];
+    this.origNamePrefix = props.model.getIn(['inputModel','cloud', 'hostname-data', 'host-prefix']);
+    this.origMemberPrefix = props.model.getIn(['inputModel','cloud', 'hostname-data', 'member-prefix']);
+    this.state = {
+      namePrefix: this.origNamePrefix.slice(),
+      memberPrefix: this.origMemberPrefix.slice(),
+      dns: JSON.parse(JSON.stringify(this.origDNS)),
+      ntp: JSON.parse(JSON.stringify(this.origNTP)),
+    };
+  }
+
+  handleInputChange = (e, valid, props) => {
+    let value = e.target.value;
+    if (valid) {
+      if (props.inputName === 'namePrefix') {
+        this.setState({namePrefix: value});
+      } else {
+        this.setState({memberPrefix: value});
+      }
+    }
+  }
+
+  getDNS = (list) => {
+    this.setState({dns: list});
+  }
+
+  getNTP = (list) => {
+    this.setState({ntp: list});
+  }
+
+  saveChanges = () => {
+    let model = this.props.model;
+    if (this.state.namePrefix !== this.origNamePrefix) {
+      model = model.updateIn(['inputModel','cloud', 'hostname-data', 'host-prefix'],
+        prefix => this.state.namePrefix);
+      this.origNamePrefix = this.state.namePrefix;
+    }
+
+    if (this.state.memberPrefix !== this.origMemberPrefix) {
+      model = model.updateIn(['inputModel','cloud', 'hostname-data', 'member-prefix'],
+        prefix => this.state.memberPrefix);
+      this.origMemberPrefix = this.state.memberPrefix;
+    }
+
+    // DNS settings can have other properties underneath such as domain, sortlist, etc. as well
+    // as no property at all, so we need to consider these cases when updating the nameservers
+    // property to make sure not to override the existing properties
+    if (JSON.stringify(this.state.dns) !== JSON.stringify(this.origDNS)) {
+        const modelDNS = model.getIn(['inputModel','cloud', 'dns-settings']);
+        // add nameservers when no property exists before
+        if (modelDNS === null) {
+            model = model.updateIn(['inputModel','cloud', 'dns-settings'],
+              dns => fromJS({nameservers: this.state.dns}));
+        } else {
+          let modelDNSObj = modelDNS.toJS();
+          if (this.state.dns.length === 0) {
+            // remove only nameservers key when there are other properties in dns-settings
+            if (Object.keys(modelDNSObj).length > 1) {
+              delete modelDNSObj.nameservers;
+              model = model.updateIn(['inputModel','cloud', 'dns-settings'],
+                dns => fromJS(modelDNSObj));
+            // set dns-settings to null to remove nameservers when no other properties exist
+            } else {
+              model = model.updateIn(['inputModel','cloud', 'dns-settings'], dns => null);
+            }
+          } else {
+            // update or add nameservers to existing dns-setttings
+            modelDNSObj.nameservers = this.state.dns;
+            model = model.updateIn(['inputModel','cloud', 'dns-settings'],
+              dns => fromJS(modelDNSObj));
+          }
+        }
+      this.origDNS = this.state.dns;
+    }
+
+    if (JSON.stringify(this.state.ntp) !== JSON.stringify(this.origNTP)) {
+      if (this.state.ntp.length === 0) {
+        model = model.updateIn(['inputModel','cloud', 'ntp-servers'], ntp => null);
+      } else {
+        model = model.updateIn(['inputModel','cloud', 'ntp-servers'], ntp => fromJS(this.state.ntp));
+      }
+      this.origNTP = this.state.ntp;
+    }
+    this.props.updateGlobalState('model', model);
+  }
+
+  isSaveAllowed = () => {
+    const isChanged = this.state.namePrefix !== this.origNamePrefix ||
+      this.state.memberPrefix !== this.origMemberPrefix ||
+      JSON.stringify(this.state.dns) !== JSON.stringify(this.origDNS) ||
+      JSON.stringify(this.state.ntp) !== JSON.stringify(this.origNTP);
+    this.props.setDataChanged(this.props.tabIndex, isChanged);
+    return isChanged;
+  }
+
+  render() {
+    return (
+      <div className='cloud-config'>
+        <div className='details-section'>
+          <div className='config-line'>
+            <div className='config-title'>{translate('config.host.name.prefix') + ':'}</div>
+            <div className='config-input'>
+              <ServerInput inputName={'namePrefix'} inputType={'text'}
+                inputAction={this.handleInputChange} inputValue={this.state.namePrefix}/>
+            </div>
+          </div>
+          <div className='config-line'>
+            <div className='config-title'>{translate('config.host.member.prefix') + ':'}</div>
+            <div className='config-input'>
+              <ServerInput inputName={'memberPrefix'} inputType={'text'}
+                inputAction={this.handleInputChange} inputValue={this.state.memberPrefix}/>
+            </div>
+          </div>
+          <div className='config-line'>
+            <div className='config-title'>{translate('config.dns') + ':'}</div>
+            <InlineAddRemoveInput name='dns' placeholder={translate('config.dns.placeholder')}
+              values={this.state.dns} sendSelectedList={this.getDNS} editable='true'
+              isRequired='false'/>
+          </div>
+          <div className='config-line'>
+            <div className='config-title'>{translate('config.ntp') + ':'}</div>
+            <InlineAddRemoveInput name='ntp' placeholder={translate('config.ntp.placeholder')}
+              values={this.state.ntp} sendSelectedList={this.getNTP} editable='true'
+              isRequired='false'/>
+          </div>
+          <div className='btn-row details-btn'>
+            <div className='btn-container'>
+              <ActionButton key='cancel' type='default' clickAction={this.props.closeAction}
+                displayLabel={translate('cancel')}/>
+              <ActionButton key='save' clickAction={this.saveChanges}
+                displayLabel={translate('save')} isDisabled={!this.isSaveAllowed()}/>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default CloudConfigTab;

--- a/src/pages/ServerRoleSummary/DiskModelDetails.js
+++ b/src/pages/ServerRoleSummary/DiskModelDetails.js
@@ -82,6 +82,27 @@ class DiskModelDetails extends Component {
     this.thirdDetailsChanged = false;
   }
 
+  resetData = () => {
+    this.setState({
+      diskModelName: '',
+      volumeGroups: [],
+      deviceGroups: [],
+      volumeGroup: {},
+      logicalVolume: {},
+      physicalVolumes: [],
+      logicalVolumes: [],
+      deviceGroup: {},
+      deviceGroupDevices: [],
+      deviceGroupConsumer: {},
+      showThirdDetails: false,
+      showRemoveVGConfirmation: false,
+      showRemoveDGConfirmation: false,
+      showRemoveLVConfirmation: false,
+      selectedRow: undefined,
+      consumerAttrsValid: true
+    });
+  }
+
   handleInputLine = (e, valid, props) => {
     const value = e.target.value;
     if (e.target.name === 'dmName') {
@@ -308,7 +329,8 @@ class DiskModelDetails extends Component {
         this.state.logicalVolume.fstype !== this.origLV.fstype ||
         this.state.logicalVolume['mkfs-opts'] !== this.origLV['mkfs-opts'];
     }
-    this.props.setDataChanged(3, this.diskModelChanged || this.secondDetailsChanged || this.thirdDetailsChanged);
+    this.props.setDataChanged(this.props.tabIndex,
+      this.diskModelChanged || this.secondDetailsChanged || this.thirdDetailsChanged);
     return dataValid;
   }
 
@@ -492,7 +514,8 @@ class DiskModelDetails extends Component {
           JSON.stringify(devices) !== JSON.stringify(this.origDGDevices);
       }
     }
-    this.props.setDataChanged(3, this.diskModelChanged || this.secondDetailsChanged || this.thirdDetailsChanged);
+    this.props.setDataChanged(this.props.tabIndex,
+      this.diskModelChanged || this.secondDetailsChanged || this.thirdDetailsChanged);
     return dataValid;
   }
 
@@ -686,7 +709,8 @@ class DiskModelDetails extends Component {
         JSON.stringify(vgs) !== JSON.stringify(this.origVGs) ||
         JSON.stringify(dgs) !== JSON.stringify(this.origDGs);
     }
-    this.props.setDataChanged(3, this.diskModelChanged || this.secondDetailsChanged || this.thirdDetailsChanged);
+    this.props.setDataChanged(this.props.tabIndex,
+      this.diskModelChanged || this.secondDetailsChanged || this.thirdDetailsChanged);
     return dataValid;
   }
 
@@ -694,7 +718,7 @@ class DiskModelDetails extends Component {
     this.diskModelChanged = false;
     this.secondDetailsChanged = false;
     this.thirdDetailsChanged = false;
-    this.props.setDataChanged(3, false);
+    this.props.setDataChanged(this.props.tabIndex, false);
     this.props.closeAction();
   }
 

--- a/src/pages/ServerRoleSummary/DiskModelsTab.js
+++ b/src/pages/ServerRoleSummary/DiskModelsTab.js
@@ -32,6 +32,19 @@ class DiskModelsTab extends Component {
     };
   }
 
+  resetData = () => {
+    this.setState({
+      diskModel: '',
+      showDiskModelDetails: false,
+      showRemoveConfirmation: false,
+      diskModelToRemove: '',
+      extendedDetails: 0
+    });
+    if (this.diskModelDetails) {
+      this.diskModelDetails.resetData();
+    }
+  }
+
   setExtendedDetails = (value) => {
     this.setState({extendedDetails: value});
   }
@@ -124,7 +137,8 @@ class DiskModelsTab extends Component {
       detailsSection = (<DiskModelDetails model={this.props.model}
         diskModel={this.state.diskModel} updateGlobalState={this.props.updateGlobalState}
         closeAction={this.hideDiskModelDetails} extendAction={this.setExtendedDetails}
-        setDataChanged={this.props.setDataChanged}/>);
+        setDataChanged={this.props.setDataChanged} tabIndex={this.props.tabIndex}
+        ref={instance => {this.diskModelDetails = instance;}}/>);
     }
 
     let confirmRemoveSection = '';

--- a/src/pages/ServerRoleSummary/EditCloudSettings.js
+++ b/src/pages/ServerRoleSummary/EditCloudSettings.js
@@ -16,6 +16,7 @@ import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { Tabs, Tab } from 'react-bootstrap';
 import { ConfirmModal, YesNoModal } from '../../components/Modals.js';
+import CloudConfigTab from './CloudConfigTab.js';
 import NicMappingTab from './NicMappingTab.js';
 import ServerGroupsTab from './ServerGroupsTab.js';
 import NetworksTab from './NetworksTab.js';
@@ -23,22 +24,26 @@ import DiskModelsTab from './DiskModelsTab.js';
 import InterfaceModelsTab from './InterfaceModelsTab.js';
 
 const TAB = {
+  CLOUD_CONFIG: 'CLOUD_CONFIG',
   NIC_MAPPINGS: 'NIC_MAPPINGS',
   SERVER_GROUPS: 'SERVER_GROUPS',
   NETWORKS: 'NETWORKS',
   DISK_MODELS: 'DISK_MODELS',
   INTERFACE_MODELS: 'INTERFACE_MODELS'
 };
+const TABINDEX = [
+  'CLOUD_CONFIG', 'NIC_MAPPINGS', 'SERVER_GROUPS', 'NETWORKS', 'DISK_MODELS', 'INTERFACE_MODELS'
+];
 
 class EditCloudSettings extends Component {
 
   constructor(props) {
     super(props);
     this.state = {
-      key: TAB.NIC_MAPPINGS,
+      key: TAB.CLOUD_CONFIG,
       showCloseConfirmation: false
     };
-    this.dataChanged = [false, false, false, false, false];
+    this.dataChanged = [false, false, false, false, false, false];
   }
 
   showConfirmCloseModal = () => {
@@ -50,6 +55,20 @@ class EditCloudSettings extends Component {
   }
 
   closeModals = () => {
+    this.dataChanged = [false, false, false, false, false, false];
+    if (!this.props.oneTab) {
+      this.nicMappingTab.resetData();
+      this.serverGroupsTab.resetData();
+      this.networksTab.resetData();
+      this.diskModelsTab.resetData();
+      this.interfaceModelsTab.resetData();
+    } else {
+      if (this.props.oneTab === 'server-group') {
+        this.serverGroupsTab.resetData();
+      } else {
+        this.nicMappingTab.resetData();
+      }
+    }
     this.setState({showCloseConfirmation: false});
     this.props.onHide();
   }
@@ -67,7 +86,8 @@ class EditCloudSettings extends Component {
             onSelect={(tabKey) => {this.setState({key: tabKey});}}>
             <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
               <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-                setDataChanged={this.setDataChanged}/>
+                setDataChanged={this.setDataChanged} tabIndex={TABINDEX.indexOf(TAB.SERVER_GROUPS)}
+                ref={instance => {this.serverGroupsTab = instance;}}/>
             </Tab>
           </Tabs>
         );
@@ -77,7 +97,8 @@ class EditCloudSettings extends Component {
             onSelect={(tabKey) => {this.setState({key: tabKey});}}>
             <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
               <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-                setDataChanged={this.setDataChanged}/>
+                setDataChanged={this.setDataChanged} tabIndex={TABINDEX.indexOf(TAB.NIC_MAPPINGS)}
+                ref={instance => {this.nicMappingTab = instance;}}/>
             </Tab>
           </Tabs>
         );
@@ -86,25 +107,35 @@ class EditCloudSettings extends Component {
       tabs = (
         <Tabs id='editCloudSettings' activeKey={this.state.key}
           onSelect={(tabKey) => {this.setState({key: tabKey});}}>
+          <Tab eventKey={TAB.CLOUD_CONFIG} title={translate('edit.cloud.config')}>
+            <CloudConfigTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
+              setDataChanged={this.setDataChanged} tabIndex={TABINDEX.indexOf(TAB.CLOUD_CONFIG)}
+              closeAction={this.showConfirmCloseModal}/>
+          </Tab>
           <Tab eventKey={TAB.NIC_MAPPINGS} title={translate('edit.nic.mappings')}>
             <NicMappingTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-              setDataChanged={this.setDataChanged}/>
+              setDataChanged={this.setDataChanged} tabIndex={TABINDEX.indexOf(TAB.NIC_MAPPINGS)}
+              ref={instance => {this.nicMappingTab = instance;}}/>
           </Tab>
           <Tab eventKey={TAB.SERVER_GROUPS} title={translate('edit.server.groups')}>
             <ServerGroupsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-              setDataChanged={this.setDataChanged}/>
+              setDataChanged={this.setDataChanged} tabIndex={TABINDEX.indexOf(TAB.SERVER_GROUPS)}
+              ref={instance => {this.serverGroupsTab = instance;}}/>
           </Tab>
           <Tab eventKey={TAB.NETWORKS} title={translate('edit.networks')}>
             <NetworksTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-              setDataChanged={this.setDataChanged}/>
+              setDataChanged={this.setDataChanged} tabIndex={TABINDEX.indexOf(TAB.NETWORKS)}
+              ref={instance => {this.networksTab = instance;}}/>
           </Tab>
           <Tab eventKey={TAB.DISK_MODELS} title={translate('edit.disk.models')}>
             <DiskModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-              setDataChanged={this.setDataChanged}/>
+              setDataChanged={this.setDataChanged} tabIndex={TABINDEX.indexOf(TAB.DISK_MODELS)}
+              ref={instance => {this.diskModelsTab = instance;}}/>
           </Tab>
           <Tab eventKey={TAB.INTERFACE_MODELS} title={translate('edit.interface.models')}>
             <InterfaceModelsTab model={this.props.model} updateGlobalState={this.props.updateGlobalState}
-              setDataChanged={this.setDataChanged}/>
+              setDataChanged={this.setDataChanged} tabIndex={TABINDEX.indexOf(TAB.INTERFACE_MODELS)}
+              ref={instance => {this.interfaceModelsTab = instance;}}/>
           </Tab>
         </Tabs>
       );

--- a/src/pages/ServerRoleSummary/InterfaceModelsTab.js
+++ b/src/pages/ServerRoleSummary/InterfaceModelsTab.js
@@ -70,6 +70,28 @@ class InterfaceModelsTab extends Component {
       showRemoveInterfaceConfirmation: false,
       interfaceToRemoveIndex: undefined
     };
+
+    this.detailsChanged = false;
+  }
+
+  resetData = () => {
+    this.setState({
+      overallMode: MODE.NONE,
+      detailMode: MODE.NONE,
+      activeOverallRow: undefined,
+      activeDetailRow: undefined,
+      interfaceModel: undefined,
+      networkInterface: undefined,
+      deviceList: undefined,
+      bondDeviceName: undefined,
+      bondOptions: undefined,
+      isInterfaceModelNameValid: undefined,
+      isInterfaceNameValid: undefined,
+      isBondDeviceNameValid: undefined,
+      isBondOptionsValid: undefined,
+      showRemoveInterfaceConfirmation: false,
+      interfaceToRemoveIndex: undefined
+    });
   }
 
   /*
@@ -365,14 +387,14 @@ class InterfaceModelsTab extends Component {
         this.modelChanged = ! this.state.interfaceModel.equals(originalModel);
       }
     }
-    this.props.setDataChanged(4, this.modelChanged || this.detailsChanged);
+    this.props.setDataChanged(this.props.tabIndex, this.modelChanged || this.detailsChanged);
     return this.modelChanged;
   }
 
   closeModelDetails = () => {
     this.modelChanged = false;
     this.detailsChanged = false;
-    this.props.setDataChanged(4, false);
+    this.props.setDataChanged(this.props.tabIndex, false);
     this.setState({overallMode: MODE.NONE});
   }
 
@@ -557,7 +579,7 @@ class InterfaceModelsTab extends Component {
         this.detailsChanged = ! this.getUpdatedInterfaceModel(this.state).equals(this.state.interfaceModel);
       }
     }
-    this.props.setDataChanged(4, this.modelChanged || this.detailsChanged);
+    this.props.setDataChanged(this.props.tabIndex, this.modelChanged || this.detailsChanged);
     return this.detailsChanged;
   }
 

--- a/src/pages/ServerRoleSummary/NetworksTab.js
+++ b/src/pages/ServerRoleSummary/NetworksTab.js
@@ -30,6 +30,17 @@ class NetworksTab extends Component {
     };
   }
 
+  resetData = () => {
+    this.setState({
+      showRemoveConfirmation: false,
+      mode: MODE.NONE,
+      networkName: ''
+    });
+    if (this.updateNetworks) {
+      this.updateNetworks.resetData();
+    }
+  }
+
   handleAddNetwork = () => {
     if(this.state.mode === MODE.NONE) {
       this.setState({mode: MODE.ADD});
@@ -97,7 +108,9 @@ class NetworksTab extends Component {
           model={this.props.model} mode={this.state.mode} {...extraProps}
           updateGlobalState={this.props.updateGlobalState}
           setDataChanged={this.props.setDataChanged}
-          closeAction={this.handleCancelUpdateNetwork}/>
+          closeAction={this.handleCancelUpdateNetwork}
+          tabIndex={this.props.tabIndex}
+          ref={instance => {this.updateNetworks = instance;}}/>
       </div>
     );
   }

--- a/src/pages/ServerRoleSummary/NicMappingTab.js
+++ b/src/pages/ServerRoleSummary/NicMappingTab.js
@@ -40,6 +40,16 @@ class NicMappingTab extends Component {
     };
   }
 
+  resetData = () => {
+    this.setState({
+      mode: MODE.NONE,
+      activeRow: undefined,
+      nicMappingName: '',
+      isNameValid: true,
+      detailRows: undefined,
+    });
+  }
+
   // Returns a new model with the nic mappings in sorted order
   getSortedModel = () => {
     return this.props.model.updateIn(['inputModel','nic-mappings'],
@@ -119,7 +129,7 @@ class NicMappingTab extends Component {
           !== this.getUpdatedModel().getIn(['inputModel', 'nic-mappings', this.state.activeRow]);
       }
     }
-    this.props.setDataChanged(0, isChanged);
+    this.props.setDataChanged(this.props.tabIndex, isChanged);
     return isChanged;
   }
 
@@ -232,7 +242,7 @@ class NicMappingTab extends Component {
   }
 
   closeDetails = () => {
-    this.props.setDataChanged(0, false);
+    this.props.setDataChanged(this.props.tabIndex, false);
     this.setState({mode: MODE.NONE});
   }
 

--- a/src/pages/ServerRoleSummary/ServerGroupDetails.js
+++ b/src/pages/ServerRoleSummary/ServerGroupDetails.js
@@ -45,6 +45,14 @@ class ServerGroupDetails extends Component {
     }
   }
 
+  resetData = () => {
+    this.setState({
+      name: '',
+      networks: [],
+      serverGroups: []
+    });
+  }
+
   handleInputLine = (e, valid, props) => {
     let value = e.target.value;
     this.setState({name: value});
@@ -99,12 +107,12 @@ class ServerGroupDetails extends Component {
         dataChanged = false;
       }
     }
-    this.props.setDataChanged(1, dataChanged);
+    this.props.setDataChanged(this.props.tabIndex, dataChanged);
     return dataChanged;
   }
 
   closeAction = () => {
-    this.props.setDataChanged(1, false);
+    this.props.setDataChanged(this.props.tabIndex, false);
     this.props.closeAction();
   }
 

--- a/src/pages/ServerRoleSummary/ServerGroupsTab.js
+++ b/src/pages/ServerRoleSummary/ServerGroupsTab.js
@@ -31,6 +31,18 @@ class ServerGroupsTab extends Component {
     };
   }
 
+  resetData = () => {
+    this.setState({
+      value: '',
+      showServerGroupDetails: false,
+      showRemoveConfirmation: false,
+      serverGroupToRemove: ''
+    });
+    if (this.serverGroupDetails) {
+      this.serverGroupDetails.resetData();
+    }
+  }
+
   addServerGroup = () => {
     if (!this.state.showServerGroupDetails) {
       this.setState({showServerGroupDetails: true, value: ''});
@@ -120,7 +132,8 @@ class ServerGroupsTab extends Component {
     if (this.state.showServerGroupDetails) {
       detailsSection = (<ServerGroupDetails model={this.props.model}
         value={this.state.value} updateGlobalState={this.props.updateGlobalState}
-        setDataChanged={this.props.setDataChanged} closeAction={this.hideServerGroupDetails}/>);
+        setDataChanged={this.props.setDataChanged} closeAction={this.hideServerGroupDetails}
+        tabIndex={this.props.tabIndex} ref={instance => {this.serverGroupDetails = instance;}}/>);
     }
 
     let confirmRemoveSection = '';

--- a/src/pages/ServerRoleSummary/UpdateNetworks.js
+++ b/src/pages/ServerRoleSummary/UpdateNetworks.js
@@ -44,9 +44,14 @@ class UpdateNetworks extends Component {
       data: networks,
     };
 
-    if (this.props.mode === MODE.EDIT) {
-      this.origData = networks;
-    }
+    this.origData = networks;
+  }
+
+  resetData = () => {
+    this.setState({
+      isFormValid: false,
+      data: {addresses: []},
+    });
   }
 
   initAddresses(networks) {
@@ -311,12 +316,12 @@ class UpdateNetworks extends Component {
 
   checkDataToSave = () => {
     const dataChanged = JSON.stringify(this.origData) !== JSON.stringify(this.state.data);
-    this.props.setDataChanged(2, dataChanged);
+    this.props.setDataChanged(this.props.tabIndex, dataChanged);
     return this.state.isFormValid && dataChanged;
   }
 
   closeAction = () => {
-    this.props.setDataChanged(2, false);
+    this.props.setDataChanged(this.props.tabIndex, false);
     this.props.closeAction();
   }
 
@@ -339,7 +344,7 @@ class UpdateNetworks extends Component {
           {this.renderNetworkAddresses()}
           <div className='details-group-title'>{translate('network.gateway') + ':'}</div>
           {this.renderNetworkInput('gateway-ip', 'text', false, translate('network.gateway'), IpV4AddressValidator)}
-          <div className='details-group-title'>{translate('network.group') + '*:'}</div>
+          <div className='details-group-title'>{translate('network.groups') + '*:'}</div>
           {this.renderNetworkGroup()}
           {this.renderTaggedVLAN()}
           <div className='btn-row details-btn network-more-width'>

--- a/src/styles/pages/ServerRoleSummary.less
+++ b/src/styles/pages/ServerRoleSummary.less
@@ -261,6 +261,34 @@
   .action-column:last-child {
     margin-bottom: 2em;
   }
+
+  .cloud-config {
+    margin: 1em 0 3em 5em;
+    .config-line {
+      display: flex;
+      margin-bottom: 1em;
+    }
+    .config-title {
+      width: 15%;
+      margin-right: 2em;
+      text-align: right;
+      font-weight: bold;
+      padding-top: 5px;
+    }
+    .config-input {
+      width: 30em;
+      .server-input {
+        width: 85%;
+      }
+      .server-input input {
+        width: 100%;
+      }
+    }
+    .dropdown-plus-minus {
+      width: 30em;
+      margin-bottom: 0.5em;
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
SCRD-2410  We added a new tab "Cloud Configuration" to the Manage Cloud Settings modal to allow the user to provide the NTP and DNS settings. The user can update the Host Name Prefix and Host Member Prefix values on this tab as well. 

This UI change also contains the resetting of data changes in each tab every time the modal is closed. This is to keep track of changes correctly, otherwise when the modal is launched again and even no change was made, the modal might still think that there're changes and keeps popping up the confirmation modal when the user wants to exit. 