### PR TITLE
Fixed the status problem for cloud deploy process

### DIFF
--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -63,12 +63,12 @@ const PLAYBOOK_STEPS = [
   },
   {
     label: translate('deploy.progress.step5'),
-    playbooks: ['hlm-status.yml']
-    //playbooks: ['ops-console-status.yml']//swap these to test-run using a short running playbook
+    playbooks: ['ardana-status.yml']
   },
   {
     label: translate('deploy.progress.step6'),
-    playbooks: ['site.yml', 'dayzero-site.yml'] //either site.yml or dayzero-site.yml
+    playbooks: ['site.yml', 'dayzero-site.yml'], //either site.yml or dayzero-site.yml
+    orCondition: true
   }
 ];
 


### PR DESCRIPTION
This checkin includes:
1. Fixed the status problem where the status was not updated correctly
when there are some playbooks included in step but acutally they might
not get run based on user settings,  for example monasca playbooks.
2. Also added a condition where to detect only need one playbook gets run
to decide if the step completes. For example site.yml or dayzero-site.yml.
3. Updated to have ardana-status.yml for the health step