### PR TITLE
Add guidance when OS install or cloud deploy fails

### DIFF
--- a/src/components/Messages.js
+++ b/src/components/Messages.js
@@ -71,8 +71,18 @@ function InfoBanner(props) {
   );
 }
 
-module.exports = {
-  ErrorMessage: ErrorMessage,
-  SuccessMessage: SuccessMessage,
-  InfoBanner: InfoBanner
-};
+function ErrorBanner(props) {
+  let banner = null;
+  if (props.show) {
+    banner = (
+      <Alert bsStyle="danger">
+        <span className='error-banner'>
+          <i className='material-icons error-icon'>error</i>{props.message}
+        </span>
+      </Alert>
+    );
+  }
+  return banner;
+}
+
+export {ErrorMessage, SuccessMessage, InfoBanner, ErrorBanner}

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -336,6 +336,7 @@
     "deploy.fail.launch.playbook": "Failed to launch playbook {0}. {1}",
     "deploy.get.event.error": "Failed to get the event for playbook {0} - {1}. {2}",
     "deploy.get.log.error": "Failed to get the log for playbook {0} - {1}. {2}",
+    "deploy.progress.failure": "Cloud provisioning has failed. Please review the errors in the log, hit Back, address the issue by editing any necessary files, re-run Validate, and Deploy again.",
 
     "install.progress.heading": "SLES Installation In Progress",
     "install.progress.step1": "Verify IPMI Connectivity",
@@ -352,7 +353,7 @@
     "provision.server.right.table": "Selected Servers",
     "provision.server.install": "Install",
     "provision.server.progress.heading": "Server Installation In Progress",
-    "provision.server.failure": "Server Installation Failure : {0}",
+    "provision.server.failure": "OS provisioning has failed. Please review the errors in the log, address the issue, and rerun the OS install on the hosts that have failed.",
     "provision.server.confirm.body": "You've selected to have SLES installed on {0} server(s).\n All existing data on the servers will be overwritten, including any OSes that are already installed.\n\n Are you sure you want to proceed?",
 
     "server.role.summary.heading": "Server and Server Role Summary",

--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -18,6 +18,7 @@ import { translate } from '../localization/localize.js';
 import { STATUS } from '../utils/constants.js';
 import BaseWizardPage from './BaseWizardPage.js';
 import { PlaybookProgress } from '../components/PlaybookProcess.js';
+import { ErrorBanner } from '../components/Messages.js';
 
 /*
   Navigation rules:
@@ -154,6 +155,10 @@ class CloudDeployProgress extends BaseWizardPage {
             playbookStatus = {this.props.playbookStatus}
             steps = {PLAYBOOK_STEPS} deployConfig = {this.props.deployConfig}
             playbooks = {[PRE_DEPLOYMENT_PLAYBOOK, sitePlaybook]} payload = {payload}/>
+          <div className='banner-container'>
+            <ErrorBanner message={translate('deploy.progress.failure')}
+              show={this.state.overallStatus === STATUS.FAILED}/>
+          </div>
         </div>
         {this.renderNavButtons()}
       </div>

--- a/src/pages/SelectServersToProvision.js
+++ b/src/pages/SelectServersToProvision.js
@@ -18,6 +18,7 @@ import { translate } from '../localization/localize.js';
 import { STATUS } from '../utils/constants.js';
 import { ActionButton } from '../components/Buttons.js';
 import { YesNoModal } from '../components/Modals.js';
+import { ErrorBanner } from '../components/Messages.js';
 import BaseWizardPage from './BaseWizardPage.js';
 import TransferTable from '../components/TransferTable.js';
 import { ServerInputLine } from '../components/ServerUtils.js';
@@ -210,9 +211,13 @@ class SelectServersToProvision extends BaseWizardPage {
           </div>
           <div className='wizard-content'>
             <PlaybookProgress
-              updatePageStatus = {this.updatePageStatus} updateGlobalState = {this.props.updateGlobalState}
-              playbookStatus = {this.props.playbookStatus} steps={OS_INSTALL_STEPS}
+              updatePageStatus={this.updatePageStatus} updateGlobalState={this.props.updateGlobalState}
+              playbookStatus={this.props.playbookStatus} steps={OS_INSTALL_STEPS}
               playbooks={[INSTALL_PLAYBOOK]} payload={payload} />
+            <div className='banner-container'>
+              <ErrorBanner message={translate('provision.server.failure')}
+                show={this.state.overallStatus === STATUS.FAILED}/>
+            </div>
           </div>
         </div>);
     } else {

--- a/src/styles/components/messages.less
+++ b/src/styles/components/messages.less
@@ -38,3 +38,13 @@
     vertical-align: bottom;
   }
 }
+
+.error-banner {
+  .error-icon {
+    color: @error-icon-color;
+    font-size: 18px;
+    margin-right: 0.5em;
+    cursor: default;
+    vertical-align: bottom;
+  }
+}

--- a/src/styles/components/serverprovision.less
+++ b/src/styles/components/serverprovision.less
@@ -39,3 +39,7 @@
     float: right;
   }
 }
+
+.banner-container {
+  margin-top: 2em;
+}

--- a/src/styles/palette.less
+++ b/src/styles/palette.less
@@ -21,6 +21,7 @@
 @defaultcolor: #5F5F5F;
 
 @errorcolor: #ff420a;
+@error-icon-color: #a94442;
 
 @defaultshadow: #c5c5c5;
 


### PR DESCRIPTION
SCRD-2320 Added an error banner to the OS install page and the cloud deploy to inform the user of the next steps they could do when there's a failure in the process. 

I tested by changing the updatePageStatus function on each page to set this.state.overallStatus value to STATUS.FAILED to simulate a failure in the process.