### PR TITLE
Fix Interface Model's Network Devices dropdown

### DIFF
--- a/src/pages/ServerRoleSummary/InterfaceModelsTab.js
+++ b/src/pages/ServerRoleSummary/InterfaceModelsTab.js
@@ -695,10 +695,10 @@ class InterfaceModelsTab extends Component {
     });
   }
 
-  updateDevice = (val) => {
+  updateDevice = (val, idx) => {
     this.setState(prev => {
-      // replace the last item in the device list with a new one containing val
-      return {deviceList: prev.deviceList.pop().push(Map({'name': val}))};
+      // Update the device with the value the user has chosen
+      return {deviceList: prev.deviceList.setIn([idx, 'name'], val)};
     });
   }
 


### PR DESCRIPTION
SCRD-2482 Fixed the behavior of the Network Devices dropdown in Interface Model tab of the Manage Cloud Settings modal, which was not updating the value correctly in the edit mode. 