### PR TITLE
Updated document.title to use the branding title

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <title>SUSE OpenStack Cloud Installer</title>
+    <title>SUSE OpenStack Cloud Deployer</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <body>
     <body>

--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -323,6 +323,9 @@ class InstallWizard extends Component {
    * boilerplate ReactJS render function
    */
   render() {
+    // overwrite default tab title to use branding title
+    document.title = translate('openstack.cloud.deployer.title');
+
     const selectedModelLine = (this.state.currentStep >= 2 && this.state.model.get('name')) ?
       <h3 className='right-corner'>{translateModelName(this.state.model.get('name'))}</h3> : '';
 


### PR DESCRIPTION
This checkin fixes the problem where the tab title doesn't pick up
the branding title.
Also updated the default tab title to align with the actual title