### PR TITLE
Add confirmation modal when changing cloud model

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -52,6 +52,7 @@
 
     "model.picker.save.model.error": "Failed to save model {0}.",
     "model.picker.save.model.error.title": "Save Model Failure",
+    "model.picker.change.model.confirm": "You are about to select a different Cloud Model than what you selected before. You will lose changes that you may have set up. \n\n Are you sure you want to proceed?",
     "model.picker.get.model.error": "Failed to get model {0}.",
     "model.picker.get.model.error.title": "Get Model Failure",
     "model.picker.get.template.error": "Failed to get templates. Won't be able to show details of each model.",

--- a/src/styles/components/modelpicker.less
+++ b/src/styles/components/modelpicker.less
@@ -43,7 +43,7 @@
 }
 
 .top-spacing {
-  margin-top: 45px;
+  margin-top: 15px;
 }
 
 .no-component-centered {


### PR DESCRIPTION
SCRD-2470 Added a confirmation modal when user selected a different cloud model than before. This is a generic warning to the user and does not actually keep track of any change that may happen after the user selected a cloud model for the first time. 