### PR TITLE
Update buttons on Assign Server Roles page to default

### DIFF
--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -98,9 +98,10 @@ class LoadFileButton extends Component {
 
   render() {
     const hidden = { display: 'none' };
+    const type = this.props.type ? this.props.type : 'link';
     return (
       <span>
-        <ActionButton type='link'
+        <ActionButton type={type}
           clickAction={this.onClickShownButton}
           displayLabel={this.props.displayLabel}
           isDisabled={this.props.isDisabled || false}

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -114,6 +114,7 @@
     "add.server.manual.add": "Manual Entry",
     "add.server.add": "Add Server",
     "add.server.add.csv": "Or import servers from CSV",
+    "add.server.add.csv.alt": "Import servers from CSV",
     "csv.import.error": "CSV import error",
     "add.server.discover": "Discover",
     "add.server.conf.discover": "Configure",

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -1163,12 +1163,12 @@ class AssignServerRoles extends BaseWizardPage {
           </div>
           <div>
             <div className='btn-row action-item-right'>
-              <ActionButton
+              <ActionButton type='default'
                 clickAction={this.handleAddServerManually}
                 displayLabel={translate('add.server.add')}/>
-              <LoadFileButton
+              <LoadFileButton type='default'
                 clickAction={this.handleAddServerFromCSV}
-                displayLabel={translate('add.server.add.csv')}/>
+                displayLabel={translate('add.server.add.csv.alt')}/>
             </div>
           </div>
         </div>
@@ -1186,7 +1186,7 @@ class AssignServerRoles extends BaseWizardPage {
           <div>
             <div className='btn-row action-item-right'>
               {!this.smApiToken && this.renderConfigDiscoveryButton()}
-              <ActionButton
+              <ActionButton type='default'
                 clickAction={this.handleDiscovery}
                 displayLabel={translate('add.server.discover')}/>
             </div>


### PR DESCRIPTION
Updated buttons on Auto Discover and Manual Entry tabs on the Assign Server Roles page from primary button (green color) and link to default button (gray color). These are buttons that show up at the search bar area after some servers were discovered or added manually.