### PR TITLE
Set selected model to previously selected value after user says no

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -52,7 +52,7 @@
 
     "model.picker.save.model.error": "Failed to save model {0}.",
     "model.picker.save.model.error.title": "Save Model Failure",
-    "model.picker.change.model.confirm": "You are about to select a different Cloud Model than what you selected before. You will lose changes that you may have set up. \n\n Are you sure you want to proceed?",
+    "model.picker.change.model.confirm": "You are about to select a different Cloud Model than what you selected before. You will lose changes that you may have set up. \n\n Are you sure you want to proceed? Select Yes to proceed, select No to revert to the previously selected model.",
     "model.picker.get.model.error": "Failed to get model {0}.",
     "model.picker.get.model.error.title": "Get Model Failure",
     "model.picker.get.template.error": "Failed to get templates. Won't be able to show details of each model.",

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -409,7 +409,8 @@ class CloudModelPicker extends BaseWizardPage {
         {this.renderNavButtons()}
         <YesNoModal show={this.state.showChangeModelConfirmation} title={translate('warning')}
           yesAction={this.closeChangeModelConfirmation}
-          noAction={() => this.setState({showChangeModelConfirmation: false})}>
+          noAction={() => this.setState({showChangeModelConfirmation: false,
+            selectedModelName: this.props.model.get('name')})}>
           {translate('model.picker.change.model.confirm')}
         </YesNoModal>
       </div>


### PR DESCRIPTION
SCRD-2470 After the user selected a different input model than what they selected before and said no to the confirmation modal, the selected value will be set back to the previously selected value.