### PR TITLE
Add Showdown library to convert .md to .html

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-collapsible": "^2.0.0",
     "react-dom": "^15.6.1",
     "react-localization": "^0.1.1",
+    "showdown": "^1.8.6",
     "socket.io-client": "^2.0.3",
     "universal-cookie": "^2.1.0"
   },

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -23,6 +23,7 @@ import { LoadingMask } from '../components/LoadingMask.js';
 import { PickerButton } from '../components/Buttons.js';
 import Dropdown from '../components/Dropdown.js';
 import { YesNoModal } from '../components/Modals.js';
+import { Converter } from 'showdown';
 
 const NODE_COUNT_THRESHOLD = 30;
 const NODE_COUNT_OPT1 = '1';
@@ -369,11 +370,11 @@ class CloudModelPicker extends BaseWizardPage {
       if (template) {
         // details is the html help content read from model template fetched from the backend server.
         // It should be safe to be rendered as the raw html content in the details view.
-        details = template['overview'];
+        const converter = new Converter();
+        details = converter.makeHtml(template['overview']);
       }
       detailContent =
-        (<div><h3>{translateModelName(this.state.selectedModelName) + ' ' + translate('common.details')}</h3>
-          <div className='model-details' dangerouslySetInnerHTML={{__html: details}}/></div>);
+        (<div className='model-details' dangerouslySetInnerHTML={{__html: details}}/>);
     }
     else {
       detailContent =


### PR DESCRIPTION
SCRD-2193 The input model team no longer provides README.html files, but only README.md files. Added Showdown and used it to convert .md files back to html format in order to display the template descriptions again.
Depends on this ardana-service change: https://gerrit.suse.provo.cloud/#/c/3178