### PR TITLE
Switch from using blueish green color to main green color 

### DIFF
--- a/src/components/PlaybookProcess.js
+++ b/src/components/PlaybookProcess.js
@@ -181,7 +181,12 @@ class PlaybookProgress extends Component {
       }
 
       const statusClass = this.getStatusCSSClass(status);
-      return (<li key={index} className={statusClass}>{step.label}</li>);
+      if (status === STATUS.COMPLETE) {
+        return (<li key={index} className={statusClass}>{step.label}
+          <i className='material-icons succeed-icon'>check_circle</i></li>);
+      } else {
+        return (<li key={index} className={statusClass}>{step.label}</li>);
+      }
     });
 
     return progresses;

--- a/src/styles/components/playbookprogress.less
+++ b/src/styles/components/playbookprogress.less
@@ -25,7 +25,13 @@
       color: black;
     }
     .succeed {
-      color: @selectedcolor;
+      color: @preferredcolor;
+      .succeed-icon {
+        color: @preferredcolor;
+        position: relative;
+        top: 0.2em;
+        margin-left: 0.3em;
+      }
     }
     .fail {
       color: @errorcolor;

--- a/src/styles/components/wizard.less
+++ b/src/styles/components/wizard.less
@@ -53,7 +53,7 @@
     }
 
     &.in-progress {
-      background-color: @selectedcolor;
+      background-color: @preferredcolor;
     }
     &.in-progress:before {
       content: attr(value);

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -33,7 +33,7 @@
     top: 0.4em;
     margin-left: 0.3em;
     &.valid {
-      color: @selectedcolor;
+      color: @preferredcolor;
     }
     &.invalid {
       color: @errorcolor;

--- a/src/styles/palette.less
+++ b/src/styles/palette.less
@@ -15,7 +15,6 @@
 
 @import "branding";//branding.less
 
-@selectedcolor: #02A49C;
 @inactivecolor: #DCDDDE;
 @subheadingcolor: #5F5F5F;
 @defaultcolor: #5F5F5F;


### PR DESCRIPTION
Bugzilla 1078351 - Changed from using the blueish green color to the main green color in 3 places:
1. in-progress icon on deploy step bar - I think we used the blueish green color to differentiate the in-progress step from the previous done steps. Now that we indicated the done steps with a check mark icon, the color of in-progress and done steps can be the same.
2. cloud deploy progress text for done state on Cloud Deployment Progress page - switched to use the main green color and added a check mark icon at the end
3. validated icon on Review Configuration Files page