### PR TITLE
Add guidance on changing number of nodes

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -79,6 +79,7 @@
     "model.summary.additional": "Additional Components",
     "model.summary.edit.nodes": "Edit number of nodes",
     "model.summary.edit.min.nodes": "Edit minimum number of nodes",
+    "model.summary.change.node.warning": "In order to support high availability, it is recommended that this role have an odd number of nodes.",
 
     "validate.config.files.heading": "Review Configuration Files",
     "validate.config.files.validate": "Validate",

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -61,6 +61,17 @@ class CloudModelSummary extends BaseWizardPage {
     );
   }
 
+  getChangeNodeWarning(number) {
+    let warning = '';
+    if (this.state.activeItem && this.state.activeItem.indexOf('clusters') !== -1 && number === 3) {
+      warning = (
+      <div className='warning-banner'>
+        <InfoBanner message={translate('model.summary.change.node.warning')}/>
+      </div>);
+    }
+    return warning;
+  }
+
   // convert a delimited string (normally the state.activeItem) into a list.  Optionally
   // remove some number of trailing items from the list (to traverse higher in the structure)
   getKey(s, stripRight) {
@@ -175,6 +186,7 @@ class CloudModelSummary extends BaseWizardPage {
               </div>
               : <div />
             }
+            {this.getChangeNodeWarning(number)}
           </div>
         </div>
         {this.renderNavButtons()}

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -61,9 +61,10 @@ class CloudModelSummary extends BaseWizardPage {
     );
   }
 
-  getChangeNodeWarning(number) {
+  getChangeNodeWarning() {
     let warning = '';
-    if (this.state.activeItem && this.state.activeItem.indexOf('clusters') !== -1 && number === 3) {
+    if (this.state.activeItem && this.state.activeItem.indexOf('clusters') !== -1 &&
+      this.origActiveNodeCount === 3) {
       warning = (
       <div className='warning-banner'>
         <InfoBanner message={translate('model.summary.change.node.warning')}/>
@@ -84,6 +85,7 @@ class CloudModelSummary extends BaseWizardPage {
   // handle click on an item
   handleClick = (e) => {
     this.setState({activeItem: e.target.id});
+    this.origActiveNodeCount = this.state.controlPlane.getIn(this.getKey(e.target.id));
   }
 
   //update the state on field change
@@ -186,7 +188,7 @@ class CloudModelSummary extends BaseWizardPage {
               </div>
               : <div />
             }
-            {this.getChangeNodeWarning(number)}
+            {this.getChangeNodeWarning()}
           </div>
         </div>
         {this.renderNavButtons()}

--- a/src/styles/components/modelpicker.less
+++ b/src/styles/components/modelpicker.less
@@ -37,13 +37,16 @@
   vertical-align: top;
   position: relative;
   .details-banner {
-    max-height: 30em;
+    max-height: 25em;
     overflow: auto;
+  }
+  .warning-banner {
+    margin-top: 1em;
   }
 }
 
 .top-spacing {
-  margin-top: 15px;
+  margin-top: 20px;
 }
 
 .no-component-centered {


### PR DESCRIPTION
Bugzilla 1080184 - added an info banner on the Cloud Model Summary page when user selects a mandatory component that has 3 nodes