### PR TITLE
Remove SUSE from default page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <title>SUSE OpenStack Cloud Deployer</title>
+    <title>OpenStack Cloud Deployer</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <body>
     <body>


### PR DESCRIPTION
Bugzilla 1082464 - replaced "SUSE OpenStack Cloud Deployer" with "OpenStack Cloud Deployer" in the page title