### PR TITLE
Handle custom model names in selection page (bsc#1082586)

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -73,6 +73,7 @@
     "model.picker.filter.network-type": "Any Network Type",
     "model.picker.filter.network-type.option.flat": "Flat Network",
     "model.picker.filter.network-type.option.multi-tenant": "Multi-tenant Network",
+    "model.picker.custom-model": "## Custom model\n\nNo additional details are available for this customized model.",
 
     "model.summary.heading": "Cloud Model to Deploy",
     "model.summary.mandatory": "Mandatory Components",

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -66,6 +66,23 @@ class CloudModelPicker extends BaseWizardPage {
     fetchJson('/api/v1/clm/templates')
       .then((templates) => {
         this.templates = templates;
+
+        // If the already-selected model name is not in the list of templates, then
+        // the user is using some model with a modified name and likely other things
+        // modified as well.  When that happens, add another bogus template to choose
+        // from that reflects this.  Note that if the customer does not change this
+        // selection, then the updated model remains intact when navigating to the next
+        // page.
+        if (this.state.selectedModelName &&
+          ! this.templates.some(e => e['name'] == this.state.selectedModelName)) {
+
+          this.templates.push({
+            'name' : this.state.selectedModelName,
+            'overview' : translate('model.picker.custom-model'),
+            'metadata': { 'nodeCount': 200, 'hypervisor': [] }
+          });
+        }
+
         this.setState({loading: false});
       })
       .catch((error) => {


### PR DESCRIPTION
If the user has selected a model and progressed through the installer
and changed then name on the page that permits model editing and then
returned back to the model selection page, display (and automatically
select) a new "custom" box that reflects this change.  This permits the
user to go forward again without forcing a selection of an existing
template and overwriting their customized changes to the model.