### PR TITLE
Add Edit Server modal for servers added manually (bsc#1080193)

### DIFF
--- a/src/components/ServerTable.js
+++ b/src/components/ServerTable.js
@@ -53,9 +53,16 @@ class ServerTable extends Component {
       });
 
     // push an empty header to hold show detail icon
-    headers.push(<th key={keyCount++}></th>);
+    if (this.props.viewAction)
+      headers.push(<th key={keyCount++}></th>);
+
+    // push another empty header to hold edit icon
+    if (this.props.editAction)
+      headers.push(<th key={keyCount++}></th>);
+
     // push another empty header to hold delete icon
-    headers.push(<th key={keyCount++}></th>);
+    if (this.props.deleteAction)
+      headers.push(<th key={keyCount++}></th>);
     return (
       <tr>{headers}</tr>
     );

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -114,6 +114,7 @@
     "add.server.auto.discover": "Auto Discover",
     "add.server.manual.add": "Manual Entry",
     "add.server.add": "Add Server",
+    "edit.server": "Edit Server",
     "add.server.add.csv": "Or import servers from CSV",
     "add.server.add.csv.alt": "Import servers from CSV",
     "csv.import.error": "CSV import error",

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -869,7 +869,10 @@ class AssignServerRoles extends BaseWizardPage {
     });
     // can not find in manually added servers list
     if(idx < 0) {
-      // try the discoverd server list
+      // clear server role value
+      server.role = '';
+
+      // try the discovered server list
       idx = this.state.rawDiscoveredServers.findIndex(svr => {
         return svr['uid'] === server.uid;
       });

--- a/src/pages/AssignServerRoles/ModelServerDetails.js
+++ b/src/pages/AssignServerRoles/ModelServerDetails.js
@@ -23,7 +23,7 @@ class ModelServerDetails extends Component {
   renderTextLine(title, value) {
     return (
       <div className='detail-line'>
-        <div className='detail-heading bold'>{translate(title) + ':'}</div>
+        <div className='detail-heading configured'>{translate(title)}</div>
         <div className='info-body readonly'>{value || ''}</div>
       </div>
     );
@@ -40,12 +40,12 @@ class ModelServerDetails extends Component {
   renderDetailsContent = () => {
     if(this.props.data) {
       return (
-        <div className='server-details-container viewonly'>
+        <div className='server-details-container'>
           {this.renderTextLine('server.id.prompt', this.props.data.id)}
-          {this.renderTextLine('server.role.prompt', this.props.data.role)}
           {this.renderTextLine('server.ip.prompt', this.props.data['ip-addr'])}
           {this.renderTextLine('server.group.prompt', this.props.data['server-group'])}
           {this.renderTextLine('server.nicmapping.prompt', this.props.data['nic-mapping'])}
+          {this.renderTextLine('server.role.prompt', this.props.data.role)}
           {this.renderTextLine('server.mac.prompt', this.props.data['mac-addr'])}
           {this.renderTextLine('server.ipmi.ip.prompt', this.props.data['ilo-ip'])}
           {this.renderTextLine('server.ipmi.username.prompt', this.props.data['ilo-user'])}

--- a/src/pages/AssignServerRoles/ServersAddedManually.js
+++ b/src/pages/AssignServerRoles/ServersAddedManually.js
@@ -1,0 +1,273 @@
+// (c) Copyright 2017-2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+import React, { Component } from 'react';
+import { fromJS } from 'immutable';
+import { translate } from '../../localization/localize.js';
+import { ActionButton } from '../../components/Buttons.js';
+import { ConfirmModal } from '../../components/Modals.js';
+import { ServerInputLine, ServerDropdownLine } from '../../components/ServerUtils.js';
+import { postJson, putJson } from '../../utils/RestUtils.js';
+import { INPUT_STATUS } from '../../utils/constants.js';
+import { MODEL_SERVER_PROPS_ALL } from '../../utils/constants.js';
+import { IpV4AddressValidator, MacAddressValidator, UniqueIdValidator } from '../../utils/InputValidators.js';
+import { genUID, getNicMappings, getServerGroups, getServerRoles, getAllOtherServerIds, getCleanedServer }
+  from '../../utils/ModelUtils.js';
+
+
+class ServersAddedManually extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      validAddServerManuallyForm: false
+    };
+
+    this.newServer = {
+      'source': 'manual',
+      'id': '',
+      'uid': genUID('manual'),
+      'ip-addr': '',
+      'server-group': '',
+      'nic-mapping': '',
+      'role': '',
+      'ilo-ip': '',
+      'ilo-user': '',
+      'ilo-password': '',
+      'mac-addr': ''
+    };
+
+    this.allManualInputsStatus = {
+      'id': INPUT_STATUS.UNKNOWN,
+      'ip-addr': INPUT_STATUS.UNKNOWN,
+      'ilo-user': INPUT_STATUS.UNKNOWN,
+      'ilo-password': INPUT_STATUS.UNKNOWN,
+      'ilo-ip': INPUT_STATUS.UNKNOWN,
+      'mac-addr': INPUT_STATUS.UNKNOWN
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // set server info in edit mode
+    if (nextProps.server) {
+      this.setNewServer(nextProps.server);
+    }
+  }
+
+  isManualFormTextInputValid = () => {
+    let isAllValid = true;
+    let keys = Object.keys(this.allManualInputsStatus);
+    keys.forEach(key => {
+      let isValid = (this.allManualInputsStatus[key] === INPUT_STATUS.VALID) ||
+        // force id and ip-addr to be filled for new server
+        (key !== 'id' && key !== 'ip-addr' && this.allManualInputsStatus[key] === INPUT_STATUS.UNKNOWN);
+      isAllValid = isAllValid && isValid;
+    });
+
+    return isAllValid;
+  }
+
+  isServerInfoChanged = () => {
+    const changedList = [];
+    for (let key in this.props.server) {
+      changedList.push(this.props.server[key] !== this.newServer[key]);
+    }
+    const changed = changedList.filter(change => change === true);
+    return changed.length > 0;
+  }
+
+  updateManualFormValidity = (props, isValid) => {
+    this.allManualInputsStatus[props.inputName] = isValid ? INPUT_STATUS.VALID : INPUT_STATUS.INVALID;
+    this.setState({validAddServerManuallyForm: this.isManualFormTextInputValid()});
+  }
+
+  resetNewServer = () => {
+    this.newServer = {
+      'source': 'manual',
+      'id': '',
+      'uid': genUID('manual'),
+      'ip-addr': '',
+      'server-group': '',
+      'nic-mapping': '',
+      'role': '',
+      'ilo-ip': '',
+      'ilo-user': '',
+      'ilo-password': '',
+      'mac-addr': ''
+    };
+    this.setState({validAddServerManuallyForm: false});
+  }
+
+  setNewServer(server) {
+    this.newServer = {
+      'source': 'manual',
+      'id': server.id,
+      'uid': server.uid,
+      'ip-addr': server['ip-addr'],
+      'server-group': server['server-group'],
+      'nic-mapping': server['nic-mapping'],
+      'role': server.role,
+      'ilo-ip': server['ilo-ip'],
+      'ilo-user': server['ilo-user'],
+      'ilo-password': server['ilo-password'],
+      'mac-addr': server['mac-addr']
+    };
+  }
+
+  cancelAddServerManuallyModal = () => {
+    this.resetNewServer();
+    this.props.closeAction();
+  }
+
+  saveServersAddedManually = (serverList) => {
+    // if role is provided, add server to the model
+    let model = this.props.model;
+
+    serverList.forEach(server => {
+      if (server.role) {
+        // empty value can cause validation problem
+        let modelServer = getCleanedServer(server, MODEL_SERVER_PROPS_ALL);
+        model = model.updateIn(['inputModel', 'servers'], list => list.push(fromJS(modelServer)));
+      }
+    });
+    this.props.updateGlobalState('model', model);
+
+    if (this.props.addAction) {
+      postJson('/api/v1/server', JSON.stringify(serverList));
+      this.props.addAction(serverList);
+    } else {
+      const server = serverList[0];
+      putJson('/api/v1/server', JSON.stringify(server));
+      this.props.updateAction(server);
+    }
+
+    this.resetNewServer();
+  }
+
+  addOneServer = () => {
+    this.saveServersAddedManually([this.newServer]);
+    this.props.closeAction();
+  }
+
+  addMoreServer = () => {
+    this.saveServersAddedManually([this.newServer]);
+  }
+
+  updateServer = () => {
+    this.saveServersAddedManually([this.newServer]);
+    this.props.closeAction();
+  }
+
+  updateNewServer = (value, key) => {
+    this.newServer[key] = value;
+    if (this.props.updateAction) {
+      this.setState({validAddServerManuallyForm: this.isServerInfoChanged()});
+    }
+  }
+
+  handleInputLine = (e, valid, props) => {
+    let value = e.target.value;
+    this.updateManualFormValidity(props, valid);
+    if (valid) {
+      this.updateNewServer(value, props.inputName);
+    }
+  }
+
+  renderInputLine = (required, title, name, type, validator) => {
+    let theProps = {};
+    if (name === 'id' && this.props.show) {
+      theProps.ids =
+        getAllOtherServerIds(
+          this.props.model, this.props.rawDiscoveredServers,
+          this.props.serversAddedManually, this.newServer['id']
+        );
+    }
+
+    return (
+      <ServerInputLine isRequired={required} label={title} inputName={name} {...theProps}
+        inputType={type} inputValidate={validator} inputAction={this.handleInputLine}
+        inputValue={this.newServer[name]}/>
+    );
+  }
+
+  renderDropdownLine(required, title, name, list, defaultOption) {
+    return (
+      <ServerDropdownLine label={title} name={name} value={this.newServer[name]} optionList={list}
+        isRequired={required} selectAction={(value) => this.updateNewServer(value, name)}
+        defaultOption={defaultOption}/>
+    );
+  }
+
+  render() {
+    const serverGroups = getServerGroups(this.props.model);
+    const nicMappings = getNicMappings(this.props.model);
+    let roles = getServerRoles(this.props.model).map(e => e['serverRole']);
+    roles.unshift('');
+    if (!this.newServer.role) {
+      this.newServer.role = '';
+    }
+    if (!this.newServer['server-group']) {
+      this.newServer['server-group'] = serverGroups[0];
+    }
+    if (!this.newServer['nic-mapping']) {
+      this.newServer['nic-mapping'] = nicMappings[0];
+    }
+    let defaultOption = {
+      label: translate('server.none.prompt'),
+      value: ''
+    };
+
+    const footer = this.props.addAction ?
+      (<div className='btn-row'>
+        <ActionButton type={'default'} clickAction={this.cancelAddServerManuallyModal}
+          displayLabel={translate('cancel')}/>
+        <ActionButton type={'default'} clickAction={this.addMoreServer} displayLabel={translate('add.more')}
+          isDisabled={!this.state.validAddServerManuallyForm}/>
+        <ActionButton clickAction={this.addOneServer} displayLabel={translate('save')}
+          isDisabled={!this.state.validAddServerManuallyForm}/>
+      </div>) :
+      (<div className='btn-row'>
+        <ActionButton type={'default'} clickAction={this.cancelAddServerManuallyModal}
+          displayLabel={translate('cancel')}/>
+        <ActionButton clickAction={this.updateServer} displayLabel={translate('save')}
+          isDisabled={!this.state.validAddServerManuallyForm}/>
+      </div>);
+
+    return (
+      <ConfirmModal show={this.props.show} className={'manual-discover-modal'}
+        title={this.props.addAction ? translate('add.server.add') : translate('edit.server')}
+        onHide={this.cancelAddServerManuallyModal} footer={footer}>
+
+        <div className='server-details-container'>
+          {this.renderInputLine(true, 'server.id.prompt', 'id', 'text', UniqueIdValidator)}
+          {this.renderInputLine(true, 'server.ip.prompt', 'ip-addr', 'text', IpV4AddressValidator)}
+          {this.renderDropdownLine(true, 'server.group.prompt', 'server-group', serverGroups)}
+          {this.renderDropdownLine(true, 'server.nicmapping.prompt', 'nic-mapping', nicMappings)}
+          {this.renderDropdownLine(false, 'server.role.prompt', 'role', roles, defaultOption)}
+        </div>
+        <div className='message-line'>{translate('server.ipmi.message')}</div>
+        <div className='server-details-container'>
+          {this.renderInputLine(false, 'server.mac.prompt', 'mac-addr', 'text', MacAddressValidator)}
+          {this.renderInputLine(false, 'server.ipmi.ip.prompt', 'ilo-ip', 'text', IpV4AddressValidator)}
+          {this.renderInputLine(false, 'server.ipmi.username.prompt', 'ilo-user', 'text')}
+          {this.renderInputLine(false, 'server.ipmi.password.prompt', 'ilo-password', 'password')}
+        </div>
+
+      </ConfirmModal>
+    );
+  }
+
+}
+
+export default ServersAddedManually;

--- a/src/pages/AssignServerRoles/ViewServerDetails.js
+++ b/src/pages/AssignServerRoles/ViewServerDetails.js
@@ -13,8 +13,6 @@
 * limitations under the License.
 **/
 import React, { Component } from 'react';
-import { translate } from '../../localization/localize.js';
-import { ActionButton } from '../../components/Buttons.js';
 import SmServerDetails from './SmServerDetails.js';
 import OvServerDetails from './OvServerDetails.js';
 import ModelServerDetails from './ModelServerDetails.js';
@@ -23,10 +21,6 @@ class ViewServerDetails extends Component {
   constructor(props) {
     super(props);
     this.className = 'view-server-details ';
-  }
-
-  handleClose = () => {
-    this.props.cancelAction();
   }
 
   renderDetailsContent() {
@@ -42,20 +36,10 @@ class ViewServerDetails extends Component {
     }
   }
 
-  renderFooter() {
-    return (
-      <div className='btn-row button-container'>
-        <ActionButton
-          clickAction={this.handleClose} displayLabel={translate('common.close')}/>
-      </div>
-    );
-  }
-
   render() {
     return (
       <div className={this.className}>
         {this.renderDetailsContent()}
-        {this.renderFooter()}
       </div>
     );
   }

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -66,9 +66,10 @@ class CloudModelSummary extends BaseWizardPage {
     if (this.state.activeItem && this.state.activeItem.indexOf('clusters') !== -1 &&
       this.origActiveNodeCount === 3) {
       warning = (
-      <div className='warning-banner'>
-        <InfoBanner message={translate('model.summary.change.node.warning')}/>
-      </div>);
+        <div className='warning-banner'>
+          <InfoBanner message={translate('model.summary.change.node.warning')}/>
+        </div>
+      );
     }
     return warning;
   }

--- a/src/pages/ServerRoleSummary/CollapsibleTable.js
+++ b/src/pages/ServerRoleSummary/CollapsibleTable.js
@@ -16,7 +16,7 @@ import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import EditServerDetails from '../../components/EditServerDetails.js';
 import ViewServerDetails from '../AssignServerRoles/ViewServerDetails.js';
-import { BaseInputModal } from '../../components/Modals.js';
+import { BaseInputModal, ConfirmModal } from '../../components/Modals.js';
 import { List, Map } from 'immutable';
 import { byServerNameOrId } from '../../utils/Sort.js';
 import { getAllOtherServerIds } from '../../utils/ModelUtils.js';
@@ -134,9 +134,9 @@ class CollapsibleTable extends Component {
 
     cols.push(
       <td key='action-buttons'>
-        <span className='glyphicon glyphicon-pencil edit'
+        <span className='glyphicon glyphicon-pencil edit collapsible'
           onClick={() => this.handleShowEditServer(server)}/>
-        <span className='glyphicon glyphicon-info-sign detail-info'
+        <span className='glyphicon glyphicon-info-sign detail-info collapsible'
           onClick={() => this.handleShowServerDetails(server)}/>
       </td>
     );
@@ -202,13 +202,10 @@ class CollapsibleTable extends Component {
 
   renderServerDetailsModal() {
     return (
-      <BaseInputModal
-        show={this.state.showServerDetailsModal} className='view-details-dialog'
+      <ConfirmModal show={this.state.showServerDetailsModal} className='view-details-dialog' hideFooter
         onHide={this.handleCancelServerDetails} title={translate('view.server.details.heading')}>
-        <ViewServerDetails
-          cancelAction={this.handleCancelServerDetails} data={this.state.activeRowData}>
-        </ViewServerDetails>
-      </BaseInputModal>
+        <ViewServerDetails data={this.state.activeRowData}/>
+      </ConfirmModal>
     );
   }
   render() {

--- a/src/styles/components/buttons.less
+++ b/src/styles/components/buttons.less
@@ -164,6 +164,9 @@
   top: 0px;
   font-size: small;
   float: right;
-  padding-right: 0.5em;
+  padding-right: 3px;
   color: @info-link-color;
+  &.collapsible {
+    padding-right: 12px;
+  }
 }

--- a/src/styles/components/serverutils.less
+++ b/src/styles/components/serverutils.less
@@ -90,8 +90,8 @@
       display: inline-block;
       text-align: right;
       padding-right: 2em;
-      &.bold {
-        font-weight: 600;
+      &.configured {
+        width: 65%;
       }
     }
     .info-body {
@@ -129,10 +129,6 @@
   .input-with-button {
     display: flex;
     width: 100%;
-  }
-
-  &.viewonly {
-    margin-top: 4em;
   }
 }
 

--- a/src/styles/pages/AssignServerRoles.less
+++ b/src/styles/pages/AssignServerRoles.less
@@ -86,7 +86,7 @@
   }
 
   &.shorter-height {
-    min-height: 38em;
+    min-height: 27em;
   }
 }
 

--- a/src/utils/CsvImporter.js
+++ b/src/utils/CsvImporter.js
@@ -14,7 +14,7 @@
 **/
 import Papa from 'papaparse';
 import { IpV4AddressValidator, MacAddressValidator } from './InputValidators.js';
-import {translate} from "../localization/localize";
+import {translate} from '../localization/localize';
 
 /**
  * import CSV from the given file


### PR DESCRIPTION
Added the Edit Server modal for servers added manually. The work includes refactoring out the existing code that handles servers added manually to be it's own module and reusing it for the edit modal.

Also fixed the View Details modal so that it's look and feel is consistent with the Add and Edit modals.

The changes in CloudModalSummary and CsvImporter are fixes for lints complaints.