### PR TITLE
Fix warning modal when select template for the first time (bsc#1082902)

### DIFF
--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -145,7 +145,7 @@ class CloudModelPicker extends BaseWizardPage {
   goForward = (e) => {
     e.preventDefault();
     const propsModelName = this.props.model.get('name');
-    if (propsModelName === undefined) {
+    if (propsModelName == undefined) {
       this.saveModel();
     } else {
       if (this.state.selectedModelName !== propsModelName) {


### PR DESCRIPTION
The propsModelName variable used to return an undefined but now returns a null. This causes the warning modal to come up when the template was selected for the first time which is not a correct behavior. Changed from '===' to '==' which takes the null value into account in that check.