### PR TITLE
Add showing of shutdown instruction even with no user (bsc#1078354)

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -328,6 +328,7 @@
     "complete.message.body2": "This is the information about your cloud:",
     "complete.message.body3": "Cloud Model - {0}",
     "complete.message.body4": "Please login as {0} on your deployer and shut down the Installer UI with the following commands:",
+    "complete.message.body4a": "Please login on your deployer and shut down the Installer UI with the following commands:",
     "complete.message.body5": "cd ~/openstack/ardana/ansible",
     "complete.message.body6": "ansible-playbook -i hosts/localhost installui-stop.yml",
     "complete.message.link.heading": "Useful links:",

--- a/src/pages/Complete.js
+++ b/src/pages/Complete.js
@@ -41,7 +41,7 @@ class Complete extends BaseWizardPage {
         console.log('Unable to retrieve external URLs');// eslint-disable-line no-console
       });
 
-    fetchJson('/api/v1/clm/user')
+    fetchJson('/api/v1/user')
       .then(responseData => {
         if (responseData.username) {
           this.setState({userName: responseData.username});
@@ -59,6 +59,13 @@ class Complete extends BaseWizardPage {
     if (this.state.userName) {
       commandLines.push(<div className='body-header' key='commandLine1'>
         {translate('complete.message.body4', this.state.userName)}</div>);
+      commandLines.push(<div className='body-line' key='commandLine2'>
+        {translate('complete.message.body5')}</div>);
+      commandLines.push(<div className='body-line' key='commandLine3'>
+        {translate('complete.message.body6')}</div>);
+    } else {
+      commandLines.push(<div className='body-header' key='commandLine1'>
+        {translate('complete.message.body4a')}</div>);
       commandLines.push(<div className='body-line' key='commandLine2'>
         {translate('complete.message.body5')}</div>);
       commandLines.push(<div className='body-line' key='commandLine3'>


### PR DESCRIPTION
The current code shows the shutdown instruction only when the user name is available. This can be a problem when the user name is not retrievable. Added code to show a generic shutdown instruction when the user name is not available.Also switched to use the get user call from the shim layer instead of the ardana service.

This change depends on the change to add the get user call to the shim layer: https://github.com/ArdanaCLM/ardana-installer-server/pull/22