### PR TITLE
Fix UI go to first page when model is not retrievable (bsc#1084377)

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -91,32 +91,33 @@ class InstallWizard extends Component {
       .catch((error) => {
         console.log('Unable to retrieve saved model');// eslint-disable-line no-console
       })
-      .then(() => fetchJson('/api/v1/progress'))
-      .then((responseData) => {
-        if (! forcedReset && responseData.steps && this.areStepsInOrder(responseData.steps, this.props.pages)) {
-          this.setState(responseData);
-        } else {
-          // Set the currentStep to 0 and update its stepProgress to inprogress
-          this.setState((prevState) => {
-            var newSteps = prevState.steps.slice();
-            newSteps.splice(0, 1, {
-              name: prevState.steps[0].name,
-              stepProgress: STATUS.IN_PROGRESS
-            });
+      .finally(() => fetchJson('/api/v1/progress')
+        .then((responseData) => {
+          if (! forcedReset && responseData.steps && this.areStepsInOrder(responseData.steps, this.props.pages)) {
+            this.setState(responseData);
+          } else {
+            // Set the currentStep to 0 and update its stepProgress to inprogress
+            this.setState((prevState) => {
+              var newSteps = prevState.steps.slice();
+              newSteps.splice(0, 1, {
+                name: prevState.steps[0].name,
+                stepProgress: STATUS.IN_PROGRESS
+              });
 
-            return {
-              currentStep: 0,
-              steps: newSteps
-            };
-          }, this.persistState);
-        }})
+              return {
+                currentStep: 0,
+                steps: newSteps
+              };
+            }, this.persistState);
+          }})
+        .catch((error) => {
+          this.setState({currentStep: 0}, this.persistState);
+        })
+      )
       .then(() => {
         if (forcedReset) {
           return deleteJson('/api/v1/server?source=sm,ov,manual');
         }
-      })
-      .catch((error) => {
-        this.setState({currentStep: 0}, this.persistState);
       });
   }
 

--- a/src/localization/localize.js
+++ b/src/localization/localize.js
@@ -63,7 +63,7 @@ export function translateModelName(key) {
     // The join() corrects this by joining the elements into a signle string.
     return strings.formatString(strings['model.name.' + key]).join('');
   } catch (e) {
-    return key
+    return (key || '')
       .replace(/[-_.]/g, ' ')                            // change _, - and . to space
       .split(' ')                                        // split into words
       .map(s => s.charAt(0).toUpperCase() + s.slice(1))  // capitalize the first letter of each word

--- a/src/pages/Complete.js
+++ b/src/pages/Complete.js
@@ -54,6 +54,13 @@ class Complete extends BaseWizardPage {
 
   render() {
     const modelName = translateModelName(this.props.model.get('name'));
+    let modelLines = [];
+    if (modelName && modelName !== '') {
+      modelLines.push(<div className='body-header' key='modelLine1'>
+        {translate('complete.message.body2')}</div>);
+      modelLines.push(<div className='body-line' key='modelLine2'>
+        {translate('complete.message.body3', modelName)}</div>);
+    }
 
     let commandLines = [];
     if (this.state.userName) {
@@ -94,8 +101,7 @@ class Complete extends BaseWizardPage {
           <div className='sub-heading'>{translate('complete.message.body1')}</div>
         </Modal.Header>
         <Modal.Body>
-          <div className='body-header'>{translate('complete.message.body2')}</div>
-          <div className='body-line'>{translate('complete.message.body3', modelName)}</div>
+          {modelLines}
           {commandLines}
           {linkSection}
         </Modal.Body>


### PR DESCRIPTION
The root cause of the problem is that the get model call failed at the Complete page. This causes the progress step to get set back to the default value of 0. This fix makes sure that get progress is called whether the get model call is successful or not.

Also if the model name can't be retrieved, do not display the first two lines which show the model name.