### PR TITLE
Add tooltips to Manage Cloud Settings tabs

### DIFF
--- a/src/components/PlaybookProcess.js
+++ b/src/components/PlaybookProcess.js
@@ -556,7 +556,7 @@ class PlaybookProgress extends Component {
       // handle the case when can not receive end event for playbook
       let lastStepPlaybooks = this.props.steps[this.props.steps.length - 1].playbooks;
       if(lastStepPlaybooks.indexOf(playbookName + '.yml') !== -1) {
-         this.processEndMonitorPlaybook(playbookName);
+        this.processEndMonitorPlaybook(playbookName);
       }
     }
   }

--- a/src/pages/ServerRoleSummary/DiskModelsTab.js
+++ b/src/pages/ServerRoleSummary/DiskModelsTab.js
@@ -87,7 +87,7 @@ class DiskModelsTab extends Component {
         let numVolumeGroups = '-';
         if (m.has('volume-groups')) {
           const vgList = m.get('volume-groups').toJS();
-          const tooltipText = vgList.map(vg => vg.name).toString().replace(/,/g, ',\n');
+          const tooltipText = vgList.map(vg => vg.name).join(',\n');
           const tooltip = (<Tooltip id='volume-groups' className='cell-tooltip'>{tooltipText}</Tooltip>);
           numVolumeGroups = (
             <OverlayTrigger placement='right' overlay={tooltip}>
@@ -97,7 +97,7 @@ class DiskModelsTab extends Component {
         let numDeviceGroups = '-';
         if (m.has('device-groups')) {
           const dgList = m.get('device-groups').toJS();
-          const tooltipText = dgList.map(dg => dg.name).toString().replace(/,/g, ',\n');
+          const tooltipText = dgList.map(dg => dg.name).join(',\n');
           const tooltip = (<Tooltip id='device-groups' className='cell-tooltip'>{tooltipText}</Tooltip>);
           numDeviceGroups = (
             <OverlayTrigger placement='right' overlay={tooltip}>

--- a/src/pages/ServerRoleSummary/DiskModelsTab.js
+++ b/src/pages/ServerRoleSummary/DiskModelsTab.js
@@ -18,6 +18,7 @@ import { alphabetically } from '../../utils/Sort.js';
 import { YesNoModal } from '../../components/Modals.js';
 import { getModelIndexByName } from '../../components/ServerUtils.js';
 import DiskModelDetails from './DiskModelDetails.js';
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 
 class DiskModelsTab extends Component {
 
@@ -85,11 +86,23 @@ class DiskModelsTab extends Component {
       .map((m,idx) => {
         let numVolumeGroups = '-';
         if (m.has('volume-groups')) {
-          numVolumeGroups = m.get('volume-groups').size;
+          const vgList = m.get('volume-groups').toJS();
+          const tooltipText = vgList.map(vg => vg.name).toString().replace(/,/g, ',\n');
+          const tooltip = (<Tooltip id='volume-groups' className='cell-tooltip'>{tooltipText}</Tooltip>);
+          numVolumeGroups = (
+            <OverlayTrigger placement='right' overlay={tooltip}>
+              <span>{m.get('volume-groups').size}</span>
+            </OverlayTrigger>);
         }
         let numDeviceGroups = '-';
         if (m.has('device-groups')) {
-          numDeviceGroups = m.get('device-groups').size;
+          const dgList = m.get('device-groups').toJS();
+          const tooltipText = dgList.map(dg => dg.name).toString().replace(/,/g, ',\n');
+          const tooltip = (<Tooltip id='device-groups' className='cell-tooltip'>{tooltipText}</Tooltip>);
+          numDeviceGroups = (
+            <OverlayTrigger placement='right' overlay={tooltip}>
+              <span>{m.get('device-groups').size}</span>
+            </OverlayTrigger>);
         }
 
         const name = m.get('name');

--- a/src/pages/ServerRoleSummary/InterfaceModelsTab.js
+++ b/src/pages/ServerRoleSummary/InterfaceModelsTab.js
@@ -24,6 +24,7 @@ import { YamlValidator } from '../../utils/InputValidators.js';
 import { YesNoModal } from '../../components/Modals.js';
 import { dump,  safeLoad } from 'js-yaml';
 import { isEmpty } from 'lodash';
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 
 class InterfaceModelsTab extends Component {
 
@@ -167,10 +168,20 @@ class InterfaceModelsTab extends Component {
     // build the rows in the main table
     const rows = this.getRows()
       .map((m,idx) => {
+        let numInterfaces = '-';
+        if (m.has('network-interfaces')) {
+          const interfaceList = m.get('network-interfaces').toJS();
+          const tooltipText = interfaceList.map(i => i.name).toString().replace(/,/g, ',\n');
+          const tooltip = (<Tooltip id='interfaces' className='cell-tooltip'>{tooltipText}</Tooltip>);
+          numInterfaces = (
+            <OverlayTrigger placement='right' overlay={tooltip}>
+              <span>{m.get('network-interfaces').size}</span>
+            </OverlayTrigger>);
+        }
         return (
           <tr key={idx}>
             <td>{m.get('name')}</td>
-            <td>{m.get('network-interfaces', new List()).size}</td>
+            <td>{numInterfaces}</td>
             <td>
               <div className='row-action-container'>
                 <span className={editClass}
@@ -457,7 +468,7 @@ class InterfaceModelsTab extends Component {
                 inputValue={this.state.interfaceModel.get('name')} inputName='modelname'
                 inputType='text' inputAction={this.handleInterfaceModelNameChange}
                 disabled={this.state.detailMode !== MODE.NONE}/>
-              <div className='details-group-title'>{translate('network.interfaces') + ':'}</div>
+              <div className='details-group-title'>{translate('network.interfaces') + '* :'}</div>
               {interfaces}
               {addButton}
 
@@ -608,7 +619,7 @@ class InterfaceModelsTab extends Component {
                 inputValue={this.state.networkInterface.get('name')} inputName='interfacename'
                 inputAction={this.handleInterfaceNameChange}
                 autoFocus="true" />
-              <div className='details-group-title'>{translate('network.devices') + ':'}</div>
+              <div className='details-group-title'>{translate('network.devices') + '* :'}</div>
               {this.renderDevices()}
               {this.renderNetworkGroups()}
 

--- a/src/pages/ServerRoleSummary/InterfaceModelsTab.js
+++ b/src/pages/ServerRoleSummary/InterfaceModelsTab.js
@@ -171,7 +171,7 @@ class InterfaceModelsTab extends Component {
         let numInterfaces = '-';
         if (m.has('network-interfaces')) {
           const interfaceList = m.get('network-interfaces').toJS();
-          const tooltipText = interfaceList.map(i => i.name).toString().replace(/,/g, ',\n');
+          const tooltipText = interfaceList.map(i => i.name).join(',\n');
           const tooltip = (<Tooltip id='interfaces' className='cell-tooltip'>{tooltipText}</Tooltip>);
           numInterfaces = (
             <OverlayTrigger placement='right' overlay={tooltip}>

--- a/src/pages/ServerRoleSummary/NicMappingTab.js
+++ b/src/pages/ServerRoleSummary/NicMappingTab.js
@@ -21,6 +21,7 @@ import { ActionButton } from '../../components/Buttons.js';
 import { List, Map } from 'immutable';
 import { NetworkInterfaceValidator, PCIAddressValidator } from '../../utils/InputValidators.js';
 import { YesNoModal } from '../../components/Modals.js';
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 
 class NicMappingTab extends Component {
 
@@ -324,7 +325,13 @@ class NicMappingTab extends Component {
 
     const rows = this.getRows()
       .map((m,idx) => {
-        const numPorts = m.get('physical-ports').size;
+        const portList = m.get('physical-ports').toJS();
+        const tooltipText = portList.map(p => p['logical-name']).toString().replace(/,/g, ',\n');
+        const tooltip = (<Tooltip id='physical-ports' className='cell-tooltip'>{tooltipText}</Tooltip>);
+        const numPorts = (
+          <OverlayTrigger placement='right' overlay={tooltip}>
+            <span>{m.get('physical-ports').size}</span>
+          </OverlayTrigger>);
         return (
           <tr key={idx}>
             <td>{m.get('name')}</td>

--- a/src/pages/ServerRoleSummary/NicMappingTab.js
+++ b/src/pages/ServerRoleSummary/NicMappingTab.js
@@ -326,7 +326,7 @@ class NicMappingTab extends Component {
     const rows = this.getRows()
       .map((m,idx) => {
         const portList = m.get('physical-ports').toJS();
-        const tooltipText = portList.map(p => p['logical-name']).toString().replace(/,/g, ',\n');
+        const tooltipText = portList.map(p => p['logical-name']).join(',\n');
         const tooltip = (<Tooltip id='physical-ports' className='cell-tooltip'>{tooltipText}</Tooltip>);
         const numPorts = (
           <OverlayTrigger placement='right' overlay={tooltip}>

--- a/src/pages/ServerRoleSummary/ServerGroupsTab.js
+++ b/src/pages/ServerRoleSummary/ServerGroupsTab.js
@@ -81,7 +81,7 @@ class ServerGroupsTab extends Component {
       .map((m,idx) => {
         let numNetworks = '-';
         if (m.has('networks')) {
-          const tooltipText = m.get('networks').toJS().toString().replace(/,/g, ',\n');
+          const tooltipText = m.get('networks').join(',\n');
           const tooltip = (<Tooltip id='network' className='cell-tooltip'>{tooltipText}</Tooltip>);
           numNetworks = (
             <OverlayTrigger placement='right' overlay={tooltip}>
@@ -91,7 +91,7 @@ class ServerGroupsTab extends Component {
 
         let numServerGroups = '-';
         if (m.has('server-groups')) {
-          const tooltipText = m.get('server-groups').toJS().toString().replace(/,/g, ',\n');
+          const tooltipText = m.get('server-groups').join(',\n');
           const tooltip = (<Tooltip id='server-groups' className='cell-tooltip'>{tooltipText}</Tooltip>);
           numServerGroups = (
             <OverlayTrigger placement='right' overlay={tooltip}>

--- a/src/pages/ServerRoleSummary/ServerGroupsTab.js
+++ b/src/pages/ServerRoleSummary/ServerGroupsTab.js
@@ -18,6 +18,7 @@ import { alphabetically } from '../../utils/Sort.js';
 import { YesNoModal } from '../../components/Modals.js';
 import ServerGroupDetails from './ServerGroupDetails.js';
 import { getModelIndexByName } from '../../components/ServerUtils.js';
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 
 class ServerGroupsTab extends Component {
 
@@ -80,12 +81,22 @@ class ServerGroupsTab extends Component {
       .map((m,idx) => {
         let numNetworks = '-';
         if (m.has('networks')) {
-          numNetworks = m.get('networks').size;
+          const tooltipText = m.get('networks').toJS().toString().replace(/,/g, ',\n');
+          const tooltip = (<Tooltip id='network' className='cell-tooltip'>{tooltipText}</Tooltip>);
+          numNetworks = (
+            <OverlayTrigger placement='right' overlay={tooltip}>
+              <span>{m.get('networks').size}</span>
+            </OverlayTrigger>);
         }
 
         let numServerGroups = '-';
         if (m.has('server-groups')) {
-          numServerGroups = m.get('server-groups').size;
+          const tooltipText = m.get('server-groups').toJS().toString().replace(/,/g, ',\n');
+          const tooltip = (<Tooltip id='server-groups' className='cell-tooltip'>{tooltipText}</Tooltip>);
+          numServerGroups = (
+            <OverlayTrigger placement='right' overlay={tooltip}>
+              <span>{m.get('server-groups').size}</span>
+            </OverlayTrigger>);
         }
 
         const name = m.get('name');

--- a/src/styles/pages/ServerRoleSummary.less
+++ b/src/styles/pages/ServerRoleSummary.less
@@ -291,6 +291,13 @@
   }
 }
 
+.cell-tooltip {
+  .tooltip-inner {
+    white-space: pre-line;
+    text-align: start;
+  }
+}
+
 /*
  * CollapsibleTable
  */


### PR DESCRIPTION
SCRD-1663 Added tooltips to the number values in the table which showed the item names so the user could see the names easily without having to use the Edit function. The changes were made for the following tabs: NIC Mappings, Server Groups, Disk Models, and Interface Models

Also fixed a lint complaint in PlaybookProcess.js