### PR TITLE
Add Clear Filters button to Cloud Model Picker page

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -74,6 +74,7 @@
     "model.picker.filter.network-type": "Any Network Type",
     "model.picker.filter.network-type.option.flat": "Flat Network",
     "model.picker.filter.network-type.option.multi-tenant": "Multi-tenant Network",
+    "model.picker.filter.clear": "Clear all filters",
     "model.picker.custom-model": "## Custom model\n\nNo additional details are available for this customized model.",
 
     "model.summary.heading": "Cloud Model to Deploy",

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -24,6 +24,7 @@ import { PickerButton } from '../components/Buttons.js';
 import Dropdown from '../components/Dropdown.js';
 import { YesNoModal } from '../components/Modals.js';
 import { Converter } from 'showdown';
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 
 const NODE_COUNT_THRESHOLD = 30;
 const NODE_COUNT_OPT1 = '1';
@@ -370,13 +371,32 @@ class CloudModelPicker extends BaseWizardPage {
         );
       });
 
+      const tooltip = (
+        <Tooltip id='clear-filters' className='tooltip'>{translate('model.picker.filter.clear')}</Tooltip>);
+      const clearFilterButton = (
+        <OverlayTrigger placement='top' overlay={tooltip}>
+          <i className='material-icons clear-filters' onClick={this.clearFilters}>clear</i>
+        </OverlayTrigger>
+      );
+
       return (
         <div className='filter-bar-container'>
           <h4 className='filter-line-header'>{translate('model.picker.filter.line.header')}</h4>
           {filterDropdowns}
+          {clearFilterButton}
         </div>
       );
     }
+  }
+
+  clearFilters = () => {
+    this.setState({
+      filterNodeCount: 'none',
+      filterHypervisorType: 'none',
+      filterStorageType: 'none',
+      filterNetworkType: 'none',
+    });
+    this.selectedFilters = [];
   }
 
   renderDetails = () => {

--- a/src/styles/components/modelpicker.less
+++ b/src/styles/components/modelpicker.less
@@ -69,12 +69,19 @@
     margin-right: 2em;
   }
   .filter-box {
-    margin-right: 2em;
+    margin-right: 1.5em;
     margin-top: 3px;
   }
   .filter-box > .server-detail-select > .rounded-corner {
     width: 17em;
     height: 30px;
+  }
+  .clear-filters {
+    font-size: 18px;
+    font-weight: 600;
+    position: relative;
+    top: 10px;
+    left: -10px;
   }
 }
 


### PR DESCRIPTION
SCRD-2198 Added the 'Clear all filters' button to the Cloud Model Picker page to allow the use to reset all filters back to none.