### PR TITLE
Add option to clear out unused IPs

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -99,6 +99,8 @@
     "validate.deployment.verbosity.tooltip": "The amount of debug messages to provide during cloud deployment.",
     "validate.deployment.verbosity.lowest": "0-No debug messages",
     "validate.deployment.verbosity.highest": "4-Extremely verbose",
+    "validate.deployment.clearServers": "Clear Unused Servers/Addresses",
+    "validate.deployment.clearServers.tooltip": "Turns on remove_deleted_servers and free-unused_addresses options. These options are not needed upon initial deployment.",
 
     "validate.tab.model": "Model",
     "validate.tab.templates": "Templates and Services",

--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -145,6 +145,10 @@ class CloudDeployProgress extends BaseWizardPage {
         payload['extraVars']['encrypt'] = '';
         payload['extraVars']['rekey'] = '';
       }
+      if (this.props.deployConfig['clearServers']) {
+        payload['extraVars']['remove_deleted_servers'] = 'y';
+        payload['extraVars']['free_unused_addresses'] = 'y';
+      }
     }
 
     this.playbooks = [PRE_DEPLOYMENT_PLAYBOOK, sitePlaybook];

--- a/src/pages/ValidateConfigFiles.js
+++ b/src/pages/ValidateConfigFiles.js
@@ -323,7 +323,8 @@ class ConfigForm extends Component {
       this.state = {
         wipeDisks: false,
         encryptKey: '',
-        verbosity: 0
+        verbosity: 0,
+        clearServers: false
       };
     } else {
       this.state = props.deployConfig;
@@ -336,6 +337,10 @@ class ConfigForm extends Component {
 
   handlePasswordChange = (e) => {
     this.setState({encryptKey: e.target.value});
+  };
+
+  handleClearServers = () => {
+    this.setState({clearServers: !this.state.clearServers});
   };
 
   render() {
@@ -384,6 +389,19 @@ class ConfigForm extends Component {
               <option key="3" value="3">3</option>
               <option key="4" value="4">{translate('validate.deployment.verbosity.highest')}</option>
             </Dropdown>
+          </div>
+        </div>
+
+        <div className='detail-line'>
+          <div className='col-xs-4 label-container'>
+            {translate('validate.deployment.clearServers')}
+            <HelpText tooltipText={translate('validate.deployment.clearServers.tooltip')}/>
+          </div>
+          <div className='col-xs-8 checkbox-line'>
+            <input type='checkbox'
+              value='clearServers'
+              checked={this.state.clearServers}
+              onChange={this.handleClearServers}/>
           </div>
         </div>
       </div>

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -51,7 +51,7 @@
 }
 
 .config-form {
-  max-width: 40em;
+  max-width: 60em;
   margin-top: 2em;
   margin-left: 2em;
   .detail-line {


### PR DESCRIPTION
SCRD-2198 Added the 'Clear Unused Servers/Addresses' checkbox to the Deployment tab of the Review Configuration Files page, to allow users to clear out unused IPs

Note: when testing, please run the UI with reset=true option to make sure that the deploy configuration is initialized properly