### PR TITLE
InstallUI redirect if ardana-service requires auth (bsc#1090278)

### DIFF
--- a/src/Deployer.js
+++ b/src/Deployer.js
@@ -19,6 +19,8 @@ import { pages } from './utils/WizardDefaults.js';
 
 class Deployer extends Component {
   render() {
+    //TODO - wrap the InstallWizard with a component that varies the wizard by task
+    // and has a selection or menuing system and the login page
     return (
       <div>
         <InstallWizard pages={pages}/>

--- a/src/utils/RestUtils.js
+++ b/src/utils/RestUtils.js
@@ -143,6 +143,12 @@ function extractResponse(response) {
       if (response.ok) {
         return value;
       } else {
+        //if the status here is 401 or 403, we should redirect to the login page (once implemented)
+        // or to the cloud deployment summary
+        if((response.status === 401 || response.status === 403) &&
+           window.location.search.indexOf('login=required') === -1) {
+          window.location.replace(window.location.href + "?login=required");
+        }
         return Promise.reject(new RestError(response.statusText, response.status, value));
       }
     });


### PR DESCRIPTION
After a deployment is successful, the ardana-service is in a mode where it requires authentication to operate. This causes the installui to get a 401 error when making most calla to the ardana-service rest service. When this happens, the UI will now redirect to the deployment summary. In the future (when the day0 UI is also used for day2 operations post-install), it will instead redirect to the login screen
