### PR TITLE
WIP: one possible routing solution

### DIFF
--- a/src/Deployer.js
+++ b/src/Deployer.js
@@ -16,13 +16,35 @@ import React, { Component } from 'react';
 import './Deployer.css';
 import InstallWizard from './InstallWizard';
 import { pages } from './utils/WizardDefaults.js';
+import { HashRouter as Router, Switch } from 'react-router-dom';
+import Route from 'react-router-dom/Route';
+import { translate } from './localization/localize.js';
 
 class Deployer extends Component {
   render() {
     return (
-      <div>
-        <InstallWizard pages={pages}/>
-      </div>
+      <Router>
+        <Switch>
+          <Route path='/login' render={() => {
+            return(
+                <div>This will be the login component</div>
+            )}
+          } />
+
+          <Route path='/about' render={() => {
+              return(
+                <div>{translate('openstack.cloud.deployer.title.version')}</div>
+              )}
+          } />
+
+          <Route path='/' render={() => {
+            return(
+              <InstallWizard pages={pages} />
+            )}
+          } />
+
+        </Switch>
+      </Router>
     );
   }
 }

--- a/src/localization/bundles/en_branding.json
+++ b/src/localization/bundles/en_branding.json
@@ -1,3 +1,4 @@
 {
-    "openstack.cloud.deployer.title": "SUSE OpenStack Cloud Deployer"
+    "openstack.cloud.deployer.title": "SUSE OpenStack Cloud Deployer",
+    "openstack.cloud.deployer.title.version": "SUSE OpenStack Cloud 8"
 }

--- a/src/localization/bundles/ja_branding.json
+++ b/src/localization/bundles/ja_branding.json
@@ -1,3 +1,4 @@
 {
-    "openstack.cloud.deployer.title": "SUSE OpenStack Cloud Deployer"
+    "openstack.cloud.deployer.title": "SUSE OpenStack Cloud Deployer",
+    "openstack.cloud.deployer.title.version": "SUSE OpenStack Cloud 8"
 }


### PR DESCRIPTION
Just one possible approach to routing for the Day2 UI... when the app is up and running add a '#/about' or '#/login' to the end of the URL to see the alternate routes... this can lead to some weird urls when resetting things...  such as 'http://localhost:8081?reset=true/#/'

hold off merging this until we have a chance to discuss it and look at alternatives