### PR TITLE
Avoid unnecessary hop at startup in secured mode

### DIFF
--- a/src/Deployer.js
+++ b/src/Deployer.js
@@ -16,15 +16,57 @@ import React, { Component } from 'react';
 import './Deployer.css';
 import InstallWizard from './InstallWizard';
 import { pages } from './utils/WizardDefaults.js';
-import { HashRouter as Router, Switch } from 'react-router-dom';
+import { HashRouter as Router, Switch, Redirect } from 'react-router-dom';
 import Route from 'react-router-dom/Route';
 import { translate } from './localization/localize.js';
 import LoginPage from './pages/Login.js';
+import { fetchJson } from './utils/RestUtils.js';
+import { getAuthToken } from './utils/Auth.js';
 
 class Deployer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isSecured: undefined
+    };
+  }
+
+  componentDidMount = () => {
+    fetchJson('/api/v1/clm/is_secured')
+      .then(response => {
+        this.setState({isSecured: response['isSecured']});
+      });
+  }
+
   render() {
-    //TODO - wrap the InstallWizard with a component that varies the wizard by task
-    // and has a selection or menuing system and the login page
+
+    // Decide which path that / should route to depending on whether
+    //    the ardana service is running in secured mode and whether
+    //    we have a valid auth token
+
+    let defaultPath;
+    if (this.state.isSecured === undefined) {
+      // If the REST call has not yet completed, then show a loading page (briefly)
+      defaultPath = (
+        <div className="loading-message">{translate('wizard.loading.pleasewait')}</div>
+      );
+    } else if (this.state.isSecured) {
+      if (! getAuthToken()) {
+        // If a login is required, Redirect to the login page
+        defaultPath = <Redirect to='/login'/> ;
+      } else {
+
+        // In a secured (post-install) mode with a valid auth token.
+        // TODO - display post-install UI
+        defaultPath = (<div>Post-install UI goes here</div>);
+      }
+    } else {
+
+      // Initial, unsecured mode.  Display the InstallWizard
+      defaultPath = <InstallWizard pages={pages}/>;
+    }
+
     return (
       <Router>
         <Switch>
@@ -40,11 +82,7 @@ class Deployer extends Component {
             );}
           } />
 
-          <Route path='/' render={() => {
-            return(
-              <InstallWizard pages={pages} />
-            );}
-          } />
+          <Route path='/' render={() => defaultPath} />
 
         </Switch>
       </Router>

--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -74,15 +74,12 @@ class InstallWizard extends Component {
     this.persistedStateVars = [
       'currentStep', 'steps', 'playbookStatus', 'connectionInfo', 'deployConfig'
     ];
+  }
+
+  componentDidMount = () => {
 
     // Note: if no progress data can be found, responseData is an empty string
     const forcedReset = window.location.search.indexOf('reset=true') !== -1;
-
-    // temporary (until login is implemented) approach to handle the case where the UI
-    // is in auth-required mode... a 403 or 401 has triggered a redirect to the login URL
-    // for now, this will take users to the last page in the wizard, but in the future
-    // this will be handled in the deployer component and will redirect to a login screen
-    const requiresLogin = window.location.search.indexOf('login=required') !== -1;
 
     // Load the current state information from the backend
 
@@ -99,23 +96,9 @@ class InstallWizard extends Component {
       })
       .then(() => fetchJson('/api/v1/progress')
         .then((responseData) => {
-          if (! forcedReset && requiresLogin) { //TEMPORARY until login is implemented
-            // Set the currentStep to the last step and update its stepProgress to inprogress
-            // this handles the case where the user returns to the install UI after a deployment is completed
-            // in the future, a redirect to a login page will occur prior to this, and this section can be removed
-            this.setState((prevState) => {
-              var newSteps = prevState.steps.slice();
-              newSteps.splice((prevState.steps.length - 1), 1, {
-                name: prevState.steps[(prevState.steps.length - 1)].name,
-                stepProgress: STATUS.IN_PROGRESS
-              });
+          if (! forcedReset && responseData.steps &&
+            this.areStepsInOrder(responseData.steps, this.props.pages)) {
 
-              return {
-                currentStep: (prevState.steps.length - 1),
-                steps: newSteps
-              };
-            }, this.persistState);
-          } else if (! forcedReset && responseData.steps && this.areStepsInOrder(responseData.steps, this.props.pages)) {
             this.setState(responseData);
           } else {
             // Set the currentStep to 0 and update its stepProgress to inprogress

--- a/src/utils/Auth.js
+++ b/src/utils/Auth.js
@@ -23,8 +23,8 @@ import Cookies from 'universal-cookie';
 // Abstract base class for storing tokens
 class TokenStore {
   setAuthToken() { throw new Error('Method setAuthToken() must be implemented'); }
-  getAuthToken() { throw new Error('Method setAuthToken() must be implemented'); }
-  clearAuthToken() { throw new Error('Method setAuthToken() must be implemented'); }
+  getAuthToken() { throw new Error('Method getAuthToken() must be implemented'); }
+  clearAuthToken() { throw new Error('Method clearAuthToken() must be implemented'); }
 }
 
 class CookieToken extends TokenStore {


### PR DESCRIPTION
Perform a check at the application load, before rendering the
InstallWizard, to verify whether a login screen should be displayed
instead.  Display a loading screen while this check is being made.  This
avoids temporarily showing the Install Wizard and then immediately
jumping to the login page.

Move REST calls from the InstallWizard's constructor into its
componentDidMount per ReactJS guidelines [1].  The InstallWizard may be
constructed by its parent (in Deployer.js) before deciding whether to
actually render it, so moving these REST calls to the constructor
permits the Deployer to properly avoid rendering the InstallWizard (and
avoid its REST calls) until it decides that it should.  This change
is also needed by the day 2 scenarios where the InstallWizard should not
automatically be rendered.

Prepare for day 2 by showing the install wizard only in unsecured mode,
and displaying a placeholder page after login with secured mode.

[1] https://reactjs.org/docs/react-component.html#constructor