### PR TITLE
SCRD-3672 Fix id alias server-id in field_defs

### DIFF
--- a/src/utils/CsvImporter.js
+++ b/src/utils/CsvImporter.js
@@ -32,7 +32,7 @@ export function importCSV(file, restrictedValues, callback) {
   const field_defs  = {
     'id': {
       unique: true,
-      aliases: [ 'server_id', 'id' ],
+      aliases: [ 'server-id', 'id' ],
       required: true
     },
     'ip-addr': {


### PR DESCRIPTION
Fixing CsvImporter.js to allow server_id as a valid column name for importing server id.