### PR TITLE
SCRD-1994 Remove dangling symlinks

### DIFF
--- a/lib/fonts/fontawesome-webfont.eot
+++ b/lib/fonts/fontawesome-webfont.eot
@@ -1,1 +1,0 @@
-../../third_party/fonts/fontawesome-webfont.eot

--- a/lib/fonts/fontawesome-webfont.svg
+++ b/lib/fonts/fontawesome-webfont.svg
@@ -1,1 +1,0 @@
-../../third_party/fonts/fontawesome-webfont.svg

--- a/lib/fonts/fontawesome-webfont.ttf
+++ b/lib/fonts/fontawesome-webfont.ttf
@@ -1,1 +1,0 @@
-../../third_party/fonts/fontawesome-webfont.ttf

--- a/lib/fonts/fontawesome-webfont.woff
+++ b/lib/fonts/fontawesome-webfont.woff
@@ -1,1 +1,0 @@
-../../third_party/fonts/fontawesome-webfont.woff

--- a/lib/fonts/fontawesome-webfont.woff2
+++ b/lib/fonts/fontawesome-webfont.woff2
@@ -1,1 +1,0 @@
-../../third_party/fonts/fontawesome-webfont.woff2


### PR DESCRIPTION
Remove the links residing in /lib/fonts that refer to fontawesome fonts
in /thirdparty/fonts that were recently removed.