### PR TITLE
Auto focus on username field on login screen

### DIFF
--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -118,7 +118,7 @@ class LoginPage extends Component {
         <div className='col-md-5 input-section'>
           <div className='header'>{translate('login.header')}</div>
           <form onSubmit={this.handleLogin}>
-            <input type='text' className='rounded-corner' required='true'
+            <input type='text' className='rounded-corner' required='true' autoFocus='true'
               autoComplete='username' value={this.state.username}
               placeholder={translate('login.placeholder.username')} onChange={this.handleUsernameChange}/>
             <div>


### PR DESCRIPTION
When the login screen is shown, automatically move the focus to the
first field, username, to facilitate typing credentials.