### PR TITLE
Support for explicitly controlling navigation

### DIFF
--- a/src/Deployer.js
+++ b/src/Deployer.js
@@ -47,7 +47,10 @@ class Deployer extends Component {
     //    the ardana service is running in secured mode and whether
     //    we have a valid auth token
 
+    const search = new URLSearchParams(window.location.search);
+
     let defaultPath;
+
     if (this.state.isSecured === undefined) {
       // If the REST call has not yet completed, then show a loading page (briefly)
       defaultPath = (
@@ -59,13 +62,22 @@ class Deployer extends Component {
         defaultPath = <Redirect to='/login'/> ;
       } else {
 
-        // If in secured (post-install) mode with a valid auth token, display menu
-        defaultPath = <NavMenu routes={routes}/>;
+        // Go to NavMenu unless the url specifically requests the installer
+        if (search.has('start') && search.get('start').startsWith('installer')) {
+          defaultPath = <InstallWizard pages={pages}/>;
+        } else {
+          defaultPath = <NavMenu routes={routes}/>;
+        }
       }
     } else {
-
-      // Initial, unsecured mode.  Display the InstallWizard
-      defaultPath = <InstallWizard pages={pages}/>;
+        // Go to installer unless the url specifically requests the menu
+        if (search.has('start') && search.get('start').startsWith('menu')) {
+          // If in secured (post-install) mode with a valid auth token, display menu
+          defaultPath = <NavMenu routes={routes}/>;
+        } else {
+          // Initial, unsecured mode.  Display the InstallWizard
+          defaultPath = <InstallWizard pages={pages}/>;
+        }
     }
 
     return (

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -72,7 +72,12 @@ class LoginPage extends Component {
         if (wasRedirectedToLogin()) {
           navigateBack();
         } else {
-          navigateTo('/services');
+          const search = new URLSearchParams(window.location.search);
+          if (search.has('start') && search.get('start').startsWith('installer')) {
+            navigateTo('/', undefined, search.toString());
+          } else {
+            navigateTo('/services');
+          }
         }
       })
       .catch((error) => {

--- a/src/utils/RouteUtils.js
+++ b/src/utils/RouteUtils.js
@@ -20,14 +20,15 @@ import createHistory from 'history/createBrowserHistory';
  * is used (currently the HashRouter).  If this router is replaced with another, then
  * the rest of the application should not need to change.
  */
-export function navigateTo(url, state) {
+export function navigateTo(url, state, search) {
   const history = createHistory();
 
   // The HashRouter expects the location to be in the "hash" property of the location.
   // Add the destination to the history object
   history.push({
     pathname: '/',
-    hash: '#' + url
+    search: search,
+    hash: '#' + url,
   }, state);
 
   // Now navigate the browser to the newly added history entry


### PR DESCRIPTION
Normally the UI decides whether to display the menu or the installer wizard depending on whether authentication is required: If authenticating, then go to the menu (after logging in); else display the installer. Add support for the query parameter ?start=menu or ?start=installer in order to control which screen is initially displayed. This is clearly meant for developers. 

In the event that an end user discovers this feature and uses it, there is really no down-side other than some possible confusion -- all secured endpoints are still enforced on the REST service end.