### PR TITLE
Add Services Per Role page

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -465,5 +465,6 @@
     "tooltip.network.cidr": "Network address in Classless Inter-Domain Routing notation, such as 10.0.1.0/24",
     "tooltip.network.vlanid": "A valid VLAN id is an integer in the range of 1-4094.",
 
-    "services.services.per.role" : "Services Per Role"
+    "services.services.per.role" : "Services Per Role",
+    "services.role" : "Role"
 }

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -287,6 +287,7 @@
     "server_groups": "Server Groups",
     "configure": "Configure",
     "packages": "Packages",
+    "roles": "Roles",
     "add_server": "Add Server",
 
     "vlanid": "VLAN ID",
@@ -462,5 +463,7 @@
 
     "tooltip.network.addresses": "IP addresses used to limit the network access. Addresses could be an IP range or an IP address. For example, 10.0.1.1-10.0.1.10 or 10.0.1.23",
     "tooltip.network.cidr": "Network address in Classless Inter-Domain Routing notation, such as 10.0.1.0/24",
-    "tooltip.network.vlanid": "A valid VLAN id is an integer in the range of 1-4094."
+    "tooltip.network.vlanid": "A valid VLAN id is an integer in the range of 1-4094.",
+
+    "services.services.per.role" : "Services Per Role"
 }

--- a/src/pages/ServicesPerRole.js
+++ b/src/pages/ServicesPerRole.js
@@ -15,7 +15,7 @@
 
 import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
-import { fromJS } from 'immutable';
+import { fetchJson } from '../utils/RestUtils.js';
 
 class ServicesPerRole extends Component {
 

--- a/src/pages/ServicesPerRole.js
+++ b/src/pages/ServicesPerRole.js
@@ -1,0 +1,98 @@
+// (c) Copyright 2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+import React, { Component } from 'react';
+import { translate } from '../localization/localize.js';
+import { fromJS } from 'immutable';
+import { fetchJson } from '../utils/RestUtils.js';
+
+class ServicesPerRole extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      model: undefined
+    };
+  }
+
+  componentWillMount() {
+    fetchJson('/api/v1/clm/model')
+      .then(responseData => {
+        this.setState({'model': fromJS(responseData)});
+      });
+  }
+
+  render() {
+    let roles = [];
+    if (this.state.model) {
+      this.state.model.getIn(['inputModel', 'control-planes'])
+        .map(controlPlane => {
+          const commonServices = controlPlane.get('common-service-components');
+          controlPlane.get('clusters')
+            .map(cluster => {
+              const combinedServices = commonServices.concat(cluster.get('service-components'));
+              roles.push({serverRole: cluster.get('server-role'), services: combinedServices.sort().toJS()});
+            });
+          controlPlane.get('resources')
+            .map(resource => {
+              const combinedServices = commonServices.concat(resource.get('service-components'));
+              roles.push({serverRole: resource.get('server-role'), services: combinedServices.sort().toJS()});
+            });
+        });
+      this.state.model.getIn(['inputModel', 'servers'])
+        .map(server => {
+          const role = server.get('role');
+          const foundIndex = roles.findIndex(s => s.serverRole === role);
+          if (foundIndex !== -1) {
+            if (roles[foundIndex].ids) {
+              roles[foundIndex].ids.push(server.get('id'));
+            } else {
+              roles[foundIndex].ids = [server.get('id')];
+            }
+          }
+        });
+    }
+
+    const rows = roles.map((role, idx) => {
+      return (
+        <tr key={idx}>
+          <td>{role.serverRole}</td>
+          <td className="line-break">{(role.ids) ? role.ids.join('\n') : '-'}</td>
+          <td>{role.services.join(', ')}</td>
+        </tr>
+      );
+    });
+
+    return (
+      <div className='tab-content'>
+        <div className='header'>{translate('services.services.per.role')}</div>
+        <table className='table'>
+          <thead>
+            <tr>
+              <th width="20%">{translate('roles')}</th>
+              <th width="35%">{translate('servers')}</th>
+              <th width="50%">{translate('services')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+export default ServicesPerRole;

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -236,3 +236,16 @@ p {
     }
   }
 }
+
+.tab-content {
+  margin: 2em;
+  .header {
+    margin: 1em 0;
+    color: #686565;
+    font-size: 24px;
+    font-weight: 400;
+  }
+  .line-break {
+    white-space: pre;
+  }
+}

--- a/src/utils/RouteConfig.js
+++ b/src/utils/RouteConfig.js
@@ -15,6 +15,7 @@
 
 import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
+import ServicesPerRole from '../pages/ServicesPerRole';
 import { SpeedometerTest } from '../pages/SpeedometerTest';
 
 // TODO: Remove this after implementing the *real* content. (It is just a placeholder for now)
@@ -46,6 +47,7 @@ export const routes = [
     items: [
       { name: translate('packages'), slug: '/services/packages', component: Example },
       { name: translate('configure'), slug: '/services/configure', component: Example },
+      { name: translate('roles'), slug: '/services/roles', component: ServicesPerRole },
     ]
   },
   { name: translate('topology'), slug: '/topology', component: Example,


### PR DESCRIPTION
SCRD-3488 Added 'Service Per Role' which is the page under a new tab called 'Roles' off of the Services menu. The page contains three columns: Roles, Servers, and Services. The Servers column shows host IDs instead of host names at the moment. The plan is to show host names when we can get them from the output of the config processor run which will come later on.