### PR TITLE
Add Service Information page

### DIFF
--- a/src/components/NavMenu.js
+++ b/src/components/NavMenu.js
@@ -30,7 +30,7 @@ class NavMenu extends Component {
         path={e.slug}
         children={({ match }) => (
           <li >
-            <Link className={match ? 'active' : ''} to={e.slug}>{e.name}</Link>
+            <Link className={match ? 'active' : ''} to={e.items[0].slug}>{e.name}</Link>
           </li>)}
       />
     ));
@@ -60,16 +60,8 @@ class NavMenu extends Component {
       />
     ));
 
-    // Render the content of any top-level items chosen.  This permits rendering
-    // content for a top-level item even when no submenu item is chosen
-    let content = this.props.routes.map(e => (
-      <Route
-        key={e.slug}
-        exact path={e.slug}
-        component={e.component}/>
-    ));
-
-    // Render the contents of the chose submenu item.
+    // Render the contents of the chosen submenu item.
+    let content = [];
     this.props.routes.forEach(route => {
       route.items.forEach(item => {
         content.push(

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -285,6 +285,7 @@
     "networks": "Networks",
     "servers": "Servers",
     "server_groups": "Server Groups",
+    "information": "Information",
     "configure": "Configure",
     "packages": "Packages",
     "roles": "Roles",
@@ -465,6 +466,11 @@
     "tooltip.network.cidr": "Network address in Classless Inter-Domain Routing notation, such as 10.0.1.0/24",
     "tooltip.network.vlanid": "A valid VLAN id is an integer in the range of 1-4094.",
 
+    "services.info" : "Service Information",
+    "services.name" : "Name",
+    "services.description" : "Description",
+    "services.regions" : "Regions",
+    "services.endpoints" : "Endpoints",
     "services.services.per.role" : "Services Per Role",
     "services.role" : "Role"
 }

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -76,7 +76,7 @@ class LoginPage extends Component {
           if (search.has('start') && search.get('start').startsWith('installer')) {
             navigateTo('/', undefined, search.toString());
           } else {
-            navigateTo('/services');
+            navigateTo('/services/info');
           }
         }
       })

--- a/src/pages/ServiceInfo.js
+++ b/src/pages/ServiceInfo.js
@@ -1,0 +1,83 @@
+// (c) Copyright 2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+import React, { Component } from 'react';
+import { translate } from '../localization/localize.js';
+import { fetchJson } from '../utils/RestUtils.js';
+import { alphabetically } from '../utils/Sort.js';
+
+class ServiceInfo extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      services: undefined
+    };
+  }
+
+  componentWillMount() {
+    fetchJson('/api/v1/clm/endpoints')
+      .then(responseData => {
+        this.setState({services: responseData});
+      });
+  }
+
+  render() {
+    let rows = [];
+    if (this.state.services) {
+      rows = this.state.services
+        .sort((a,b) => alphabetically(a.name, b.name))
+        .map((srv, idx) => {
+          const regions = srv.endpoints.map(ep => {return ep.region;}).join('\n');
+          const endpoints = srv.endpoints.map(ep => {
+            // capitalize the interface before concat with the url
+            const types = ep.interface.charAt(0).toUpperCase() + ep.interface.substr(1);
+            return types + ' ' + ep.url;
+          }).join('\n');
+
+          return (
+            <tr key={idx}>
+              <td className='capitalize'>{srv.name}</td>
+              <td>{srv.description}</td>
+              <td className='line-break'>{endpoints}</td>
+              <td className='line-break'>{regions}</td>
+            </tr>
+          );
+        });
+    }
+
+    return (
+      <div className='tab-content'>
+        <div className='header'>{translate('services.info')}</div>
+        <table className='table'>
+          <thead>
+            <tr>
+              <th>{translate('services.name')}</th>
+              <th>{translate('services.description')}</th>
+              <th>{translate('services.endpoints')}</th>
+              <th>{translate('services.regions')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+}
+
+export default ServiceInfo;

--- a/src/pages/ServiceInfo.js
+++ b/src/pages/ServiceInfo.js
@@ -59,7 +59,7 @@ class ServiceInfo extends Component {
     }
 
     return (
-      <div className='tab-content'>
+      <div className='menu-tab-content'>
         <div className='header'>{translate('services.info')}</div>
         <table className='table'>
           <thead>

--- a/src/pages/ServicesPerRole.js
+++ b/src/pages/ServicesPerRole.js
@@ -70,7 +70,7 @@ class ServicesPerRole extends Component {
     });
 
     return (
-      <div className='tab-content-update'>
+      <div className='menu-tab-content'>
         <div className='header'>{translate('services.services.per.role')}</div>
         <table className='table'>
           <thead>

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -249,3 +249,7 @@ p {
     white-space: pre;
   }
 }
+
+.capitalize {
+  text-transform: capitalize;
+}

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -237,7 +237,7 @@ p {
   }
 }
 
-.tab-content-update {
+.menu-tab-content {
   margin: 2em;
   .header {
     margin: 1em 0;

--- a/src/utils/RouteConfig.js
+++ b/src/utils/RouteConfig.js
@@ -15,6 +15,7 @@
 
 import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
+import ServiceInfo from '../pages/ServiceInfo';
 import ServicesPerRole from '../pages/ServicesPerRole';
 import { SpeedometerTest } from '../pages/SpeedometerTest';
 
@@ -43,14 +44,15 @@ class Example extends Component {
  * Define all fixed entries on the navigation menu
  */
 export const routes = [
-  { name: translate('services'), slug: '/services', component: Example,
+  { name: translate('services'), slug: '/services',
     items: [
+      { name: translate('information'), slug: '/services/info', component: ServiceInfo },
       { name: translate('packages'), slug: '/services/packages', component: Example },
       { name: translate('configure'), slug: '/services/configure', component: Example },
       { name: translate('roles'), slug: '/services/roles', component: ServicesPerRole },
     ]
   },
-  { name: translate('topology'), slug: '/topology', component: Example,
+  { name: translate('topology'), slug: '/topology',
     items: [
       { name: translate('services'), slug: '/topology/services', component: Example },
       { name: translate('regions'), slug: '/topology/regions', component: Example },
@@ -59,13 +61,13 @@ export const routes = [
       { name: translate('server_groups'), slug: '/topology/server-groups', component: Example },
     ]
   },
-  { name: translate('servers'), slug: '/servers', component: Example,
+  { name: translate('servers'), slug: '/servers',
     items: [
       { name: translate('add_server'), slug: '/servers/add-server', component: Example },
     ]
   },
   // Avoid the hassle of creating translations for this disposable code:
-  { name: 'Example', slug: '/example', component: Example,
+  { name: 'Example', slug: '/example',
     items: [
       { name: 'Speedometer', slug: '/example/speedometer', component: SpeedometerTest },
     ]


### PR DESCRIPTION
SCRD-3484 Added 'Service Information' page which is the page under the 'Information' tab off of the Services menu. The page contains a table with four columns: Name, Description, Endpoints, and Regions. There's supposed to be the fifth column which is the 'Status' column, but we need the status data from Monasca which is not available at the moment. Once the Monasca data is available, we will need to add the Status column to the table.

Also updated how the navigation menu works by getting rid of the landing page and setting the first tab of each menu to be the default page when the menu was selected.  