### PR TITLE
Add Run Status Playbook action for services

### DIFF
--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -40,7 +40,7 @@ function CloseButton(props) {
   return (
     <ActionButton
       clickAction={props.clickAction}
-      displayLabel={props.displayLabel || translate('common.close')}
+      displayLabel={props.displayLabel || translate('close')}
       isDisabled={props.isDisabled}
     />
   );
@@ -64,6 +64,7 @@ class ActionButton extends Component {
     buttonClass += (this.props.moreClass) ? 'inline-button' : '';
     return (
       <button
+        id={this.props.id}
         className={buttonClass}
         onClick={this.props.clickAction}
         disabled={this.props.isDisabled}>{this.props.displayLabel}

--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -30,7 +30,7 @@ function ConfirmModal(props) {
       backdrop={'static'}
       dialogClassName={props.className}>
 
-      <Modal.Header closeButton>
+      <Modal.Header closeButton={!props.hideCloseButton}>
         <Modal.Title className='title'>{props.title}</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -7,7 +7,7 @@
     "next" : "Next",
     "back" : "Back",
     "cancel" : "Cancel",
-    "common.close": "Close",
+    "close": "Close",
     "common.nodata": "No Data",
     "done" : "Done",
     "none" : "None",
@@ -29,6 +29,9 @@
     "no.options.available": "No options available",
     "no.component.select": "No Component Selected",
     "no.model.select": "No Model Selected",
+    "name": "Name",
+    "description": "Description",
+    "role": "Role",
     "common.details": "Details",
     "common.delete": "Delete",
     "common.activate": "Activate",
@@ -304,6 +307,7 @@
     "configure": "Configure",
     "packages": "Packages",
     "roles": "Roles",
+    "endpoints": "Endpoints",
     "add_server": "Add Server",
 
     "vlanid": "VLAN ID",
@@ -486,10 +490,10 @@
     "tooltip.network.vlanid": "A valid VLAN id is an integer in the range of 1-4094.",
 
     "services.info" : "Service Information",
-    "services.name" : "Name",
-    "services.description" : "Description",
-    "services.regions" : "Regions",
-    "services.endpoints" : "Endpoints",
+    "services.services.per.role" : "Services Per Role",
+    "services.run.status" : "Run Status Playbook",
+    "services.status.result" : "Run Status Playbook - {0}",
+    "services.cancel.playbook" : "Cancel Playbook",
 
     "server.replace.heading": "Replace a Server - {0}",
     "server.available.prompt": "Available Servers",
@@ -510,9 +514,5 @@
     "server.replace.complete": "Completed replacing server {0}",
     "server.replace.prepare.failure": "Failed to prepare for replacing server",
     "update.commit.failure": "Failed to commit update changes. {0}",
-    "install.progress.failure": "Failed to install SLES OS",
-
-    "services.services.per.role" : "Services Per Role",
-    "services.role" : "Role"
-
+    "install.progress.failure": "Failed to install SLES OS"
 }

--- a/src/pages/ServiceInfo.js
+++ b/src/pages/ServiceInfo.js
@@ -17,21 +17,74 @@ import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
 import { fetchJson } from '../utils/RestUtils.js';
 import { alphabetically } from '../utils/Sort.js';
+import { PlaybookProgress } from '../components/PlaybookProcess.js';
+import { LoadingMask } from '../components/LoadingMask.js';
+import ContextMenu from '../components/ContextMenu.js';
 
 class ServiceInfo extends Component {
 
   constructor() {
     super();
     this.state = {
-      services: undefined
+      services: undefined,
+      showActionMenu: false,
+      showDetailsModal: false,
+      showRunStatusPlaybookModal: false,
+      playbooks: [],
+      steps: [],
+      selectedService: '',
+      showLoadingMask: false,
+      menuLocation: undefined
     };
   }
 
   componentWillMount() {
+    this.setState({showLoadingMask: true});
     fetchJson('/api/v1/clm/endpoints')
       .then(responseData => {
-        this.setState({services: responseData});
+        this.setState({services: responseData, showLoadingMask: false});
       });
+  }
+
+  renderActionMenuIcon = (service) => {
+    return (
+      <span onClick={(event) => this.handleActionMenu(event, service)}>
+        <i className='material-icons'>more_horiz</i>
+      </span>
+    );
+  }
+
+  handleActionMenu = (event, service) => {
+    this.setState({
+      showActionMenu: true,
+      selectedService: service,
+      menuLocation: {x: event.pageX, y: event.pageY}
+    });
+  }
+
+  showDetailsModal = () => {
+    this.setState({showActionMenu: false});
+  }
+
+  showRunStatusPlaybookModal = () => {
+    const playbookName = this.state.selectedService + '-status';
+    this.setState({
+      showActionMenu: false,
+      showRunStatusPlaybookModal: true,
+      playbooks: [playbookName],
+      steps: [{label: 'status', playbooks: [playbookName + '.yml']}],
+    });
+  }
+
+  renderMenuItems = () => {
+    const menuItems = [
+      {show: true, key: 'common.details', handleShowModal: this.showDetailsModal},
+      {show: true, key: 'services.run.status', handleShowModal: this.showRunStatusPlaybookModal},
+    ];
+    return (
+      <ContextMenu show={this.state.showActionMenu} items={menuItems} location={this.state.menuLocation}
+        close={() => this.setState({showActionMenu: false})}/>
+    );
   }
 
   render() {
@@ -43,7 +96,7 @@ class ServiceInfo extends Component {
           const regions = srv.endpoints.map(ep => {return ep.region;}).join('\n');
           const endpoints = srv.endpoints.map(ep => {
             // capitalize the interface before concat with the url
-            const types = ep.interface.charAt(0).toUpperCase() + ep.interface.substr(1);
+            const types = ep.interface[0].toUpperCase() + ep.interface.substr(1);
             return types + ' ' + ep.url;
           }).join('\n');
 
@@ -53,27 +106,44 @@ class ServiceInfo extends Component {
               <td>{srv.description}</td>
               <td className='line-break'>{endpoints}</td>
               <td className='line-break'>{regions}</td>
+              <td>{this.renderActionMenuIcon(srv.name)}</td>
             </tr>
           );
         });
     }
 
+    let statusModal;
+    if (this.state.showRunStatusPlaybookModal) {
+      const serviceName = this.state.selectedService[0].toUpperCase() + this.state.selectedService.substr(1);
+      statusModal = (
+        <PlaybookProgress steps={this.state.steps} playbooks={this.state.playbooks}
+          updatePageStatus={() => {}} modalMode showModal={this.state.showRunStatusPlaybookModal}
+          onHide={() => this.setState({showRunStatusPlaybookModal: false})} serviceName={serviceName}/>
+      );
+    }
+
     return (
-      <div className='menu-tab-content'>
-        <div className='header'>{translate('services.info')}</div>
-        <table className='table'>
-          <thead>
-            <tr>
-              <th>{translate('services.name')}</th>
-              <th>{translate('services.description')}</th>
-              <th>{translate('services.endpoints')}</th>
-              <th>{translate('services.regions')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows}
-          </tbody>
-        </table>
+      <div>
+        {statusModal}
+        <LoadingMask show={this.state.showLoadingMask}></LoadingMask>
+        <div className='menu-tab-content'>
+          <div className='header'>{translate('services.info')}</div>
+          <table className='table'>
+            <thead>
+              <tr>
+                <th>{translate('name')}</th>
+                <th>{translate('description')}</th>
+                <th>{translate('endpoints')}</th>
+                <th>{translate('regions')}</th>
+                <th width="3em"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows}
+            </tbody>
+          </table>
+          {this.state.showActionMenu && this.renderMenuItems()}
+        </div>
       </div>
     );
   }

--- a/src/pages/ServicesPerRole.js
+++ b/src/pages/ServicesPerRole.js
@@ -75,7 +75,7 @@ class ServicesPerRole extends Component {
         <table className='table'>
           <thead>
             <tr>
-              <th width="20%">{translate('services.role')}</th>
+              <th width="20%">{translate('role')}</th>
               <th width="35%">{translate('servers')}</th>
               <th width="50%">{translate('services')}</th>
             </tr>

--- a/src/styles/components/contextmenu.less
+++ b/src/styles/components/contextmenu.less
@@ -32,7 +32,7 @@
     padding: 0.2em 1.5em;
     border-bottom: 1px solid @box-border-color;
     &:hover {
-      background: @inactivecolor;
+      background: @main-menu-active-bg-color;
       width: 100%
     }
   }

--- a/src/styles/components/playbookprogress.less
+++ b/src/styles/components/playbookprogress.less
@@ -53,3 +53,7 @@
     font-size: 1.1em;
   }
 }
+
+.status-modal {
+  min-width: 70em;
+}


### PR DESCRIPTION
SCRD-3485 Added a drop down menu that contained 'Details' and 'Run Status Playbook' actions for each service in the Service Information page. Then implemented the modal dialog that showed the streaming of result from running status playbook for the selected service. The Details menu doesn't do anything at the moment.