### PR TITLE
Add region topology page

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-collapsible": "^2.0.0",
     "react-dom": "^16.4.1",
     "react-localization": "^0.1.1",
+    "react-router-hash-link": "^1.2.0",
     "showdown": "^1.8.6",
     "socket.io-client": "^2.0.3",
     "universal-cookie": "^2.1.0",

--- a/src/pages/topology/ControlPlanes.js
+++ b/src/pages/topology/ControlPlanes.js
@@ -15,7 +15,7 @@
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import '../../styles/deployer.less';
-import { fetchJson } from '../../utils/RestUtils.js';
+import { getInternalModel } from './TopologyUtils.js';
 
 const Fragment = React.Fragment;
 /*
@@ -35,7 +35,6 @@ class ControlPlanes extends Component {
     this.control_planes = undefined;
     this.servers = undefined;
     this.server_by_hostname = {};
-
   }
 
   init = () => {
@@ -53,19 +52,18 @@ class ControlPlanes extends Component {
     }
   }
 
-  componentWillMount() {
-    this.setState({loading: true});
+  componentDidMount() {
 
-    // Load overview for all templates
-    fetchJson('/api/v1/clm/model/cp_internal/CloudModel.yaml')
+    getInternalModel()
       .then((yml) => {
 
-        // Force a re-render
-        this.setState({
-          model: yml});
+        // Force a re-render if the page is still shown (user may navigate away while waiting)
+        if (this.refs.control_planes)
+          this.setState({
+            model: yml});
       })
       .catch((error) => {
-        // console.log(error);
+        console.log(error); // eslint-disable-line no-console
       });
   }
 
@@ -215,7 +213,7 @@ class ControlPlanes extends Component {
 
     return (
       <div key={cp_name} className='menu-tab-content'>
-        <a name={cp_name} />
+        <a id={cp_name}/>
         <div className='header'>{translate('control_plane', cp_name)}</div>
         <table className='table'>
           <thead><tr>
@@ -248,7 +246,7 @@ class ControlPlanes extends Component {
     }
 
     return (
-      <div className='wizard-page'>
+      <div ref="control_planes" className='wizard-page'>
         <div className='wizard-content'>
           {control_planes}
         </div>

--- a/src/pages/topology/ControlPlanes.js
+++ b/src/pages/topology/ControlPlanes.js
@@ -244,7 +244,7 @@ class ControlPlanes extends Component {
         <div className='wizard-content'>
           {control_planes}
         </div>
-        <div className='notification-message-container'>
+        <div className='banner-container'>
           <ErrorBanner message={this.state.errorMessage} show={this.state.errorMessage !== undefined} />
         </div>
       </div>

--- a/src/pages/topology/Regions.js
+++ b/src/pages/topology/Regions.js
@@ -1,0 +1,139 @@
+// (c) Copyright 2017-2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+import React, { Component } from 'react';
+import { HashLink } from 'react-router-hash-link';
+import { translate } from '../../localization/localize.js';
+import '../../styles/deployer.less';
+import { getInternalModel } from './TopologyUtils.js';
+
+/*
+ * This class is a JavaScript implementation of the script
+ * ardana_configurationprocessor/plugins/builders/HTMLDiagram/ControlPlanes.py
+ * in the config processor
+ */
+class Regions extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      model: undefined
+    };
+
+  }
+
+  componentDidMount() {
+
+    getInternalModel()
+      .then((yml) => {
+
+        // Force a re-render if the page is still shown (user may navigate away while waiting)
+        if (this.refs.regions)
+          this.setState({
+            model: yml});
+      })
+      .catch((error) => {
+        console.log(error); // eslint-disable-line no-console
+      });
+  }
+
+  render_regions = () => {
+
+    const cps = this.state.model['internal']['control-planes'];
+
+    // Build a map by region of components advertised to keystone.  Note
+    // that the component name will be the specific service, e.g. cinder-api
+    let advertised = {};
+    for (const cp of Object.values(cps)) {
+      const cp_advertised = cp['advertised'] || {};
+      for (const adv of Object.values(cp_advertised['keystone-api'] || [])) {
+        for (const region of adv['regions']) {
+          advertised[region] = advertised[region] || [];   // Seed with an empty array
+          advertised[region].push(adv['component_name']);
+        }
+      }
+    }
+    const regions = this.state.model['internal']['region-topology']['regions'];
+
+    // Build the header row of the table
+    let header_row = Object.keys(regions).sort().map(name => <th key={name}>{name}</th>);
+    header_row.unshift(<th key="cp">{translate('control_planes')}</th>);
+
+    // Build the data rows
+    const table_rows = Object.keys(cps).sort().map(cp_name => {
+
+      const columns = Object.keys(regions).sort().map(name => {
+        if (regions[name]['control_planes'][cp_name]) {
+
+          // region_svcs is an object with keys corresponding to service names (e.g. 'cinder'),
+          // and whose values are arrays of component names (e.g. 'cinder-api', 'cinder-schduler', etc.)
+          const region_svcs = regions[name]['control_planes'][cp_name]['services'];
+
+          const service_list = Object.keys(region_svcs).map(svc => {
+
+            // If any component name for this service is advertised to keystone, then
+            // highlight it in the displayed list
+            let found = false;
+            for(const component of region_svcs[svc]) {
+              if (advertised[name].includes(component)) {
+                found = true;
+                break;
+              }
+            }
+            if (found) {
+              return <div key={svc}><b>{svc}</b></div>;
+            } else {
+              return <div key={svc}>{svc}</div>;
+            }
+          });
+
+          return (<td key={name}>{service_list}</td>);
+        } else {
+          return (<td key={name} />);
+        }
+      });
+
+      const link = '/topology/control_planes#' + cp_name;
+      columns.unshift(<td key="cp"><HashLink to={link}>{cp_name}</HashLink></td>);
+
+      return <tr key={cp_name}>{columns}</tr>;
+    });
+
+
+    return (
+      <div className='menu-tab-content'>
+        <table className='table'>
+          <thead><tr>{header_row}</tr></thead>
+          <tbody>
+            {table_rows}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  render () {
+    const regions = this.state.model ? this.render_regions() : translate('loading.pleasewait');
+
+    return (
+      <div ref="regions" className='wizard-page'>
+        <div className='wizard-content'>
+          {regions}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Regions;

--- a/src/pages/topology/Regions.js
+++ b/src/pages/topology/Regions.js
@@ -135,7 +135,7 @@ class Regions extends Component {
         <div className='wizard-content'>
           {this.state.model && this.render_regions()}
         </div>
-        <div className='notification-message-container'>
+        <div className='banner-container'>
           <ErrorBanner message={this.state.errorMessage} show={this.state.errorMessage !== undefined} />
         </div>
       </div>

--- a/src/pages/topology/Regions.js
+++ b/src/pages/topology/Regions.js
@@ -17,6 +17,8 @@ import { HashLink } from 'react-router-hash-link';
 import { translate } from '../../localization/localize.js';
 import '../../styles/deployer.less';
 import { getInternalModel } from './TopologyUtils.js';
+import { ErrorBanner } from '../../components/Messages';
+import { LoadingMask } from '../../components/LoadingMask';
 
 /*
  * This class is a JavaScript implementation of the script
@@ -28,7 +30,8 @@ class Regions extends Component {
     super(props);
 
     this.state = {
-      model: undefined
+      model: undefined,
+      errorMessage: undefined,
     };
 
   }
@@ -44,7 +47,9 @@ class Regions extends Component {
             model: yml});
       })
       .catch((error) => {
-        console.log(error); // eslint-disable-line no-console
+        this.setState({
+          errorMessage: error.toString(),
+        });
       });
   }
 
@@ -124,12 +129,14 @@ class Regions extends Component {
   }
 
   render () {
-    const regions = this.state.model ? this.render_regions() : translate('loading.pleasewait');
-
     return (
       <div ref="regions" className='wizard-page'>
+        <LoadingMask show={!this.state.model && !this.state.errorMessage}/>
         <div className='wizard-content'>
-          {regions}
+          {this.state.model && this.render_regions()}
+        </div>
+        <div className='notification-message-container'>
+          <ErrorBanner message={this.state.errorMessage} show={this.state.errorMessage !== undefined} />
         </div>
       </div>
     );

--- a/src/pages/topology/TopologyUtils.js
+++ b/src/pages/topology/TopologyUtils.js
@@ -1,0 +1,30 @@
+// (c) Copyright 2017-2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+import { fetchJson } from '../../utils/RestUtils.js';
+
+// Intead of doing this base-class thing, just use something like ConfigHelper.js used
+// to do for the config promise, which is to always return a promise, which may or may
+// not have been resolved already
+//
+var modelPromise;
+
+function loadInternalModel() {
+  return fetchJson('/api/v1/clm/model/cp_internal/CloudModel.yaml');
+}
+
+export function getInternalModel() {
+  modelPromise = modelPromise || loadInternalModel();
+  return modelPromise;
+}

--- a/src/utils/RouteConfig.js
+++ b/src/utils/RouteConfig.js
@@ -70,7 +70,7 @@ export const routes = [
   { name: translate('topology'), slug: '/topology',
     items: [
       { name: translate('control_planes'), slug: '/topology/control_planes', component: ControlPlanes },
-      { name: translate('regions'), slug: '/topology/regions', component: Example },
+      { name: translate('regions'), slug: '/topology/regions', component: Regions },
       { name: translate('services'), slug: '/topology/services', component: Example , unfinished: true },
       { name: translate('networks'), slug: '/topology/networks', component: Example , unfinished: true },
       { name: translate('servers'), slug: '/topology/servers', component: Example , unfinished: true },

--- a/src/utils/RouteConfig.js
+++ b/src/utils/RouteConfig.js
@@ -23,6 +23,7 @@ import UpdateServers from '../pages/UpdateServers.js';
 import InstallWizard from '../InstallWizard.js';
 import {UpdateServerPages} from '../pages/ReplaceServer/UpdateServerPages.js';
 import ControlPlanes from '../pages/topology/ControlPlanes.js';
+import Regions from '../pages/topology/Regions.js';
 
 // TODO: Remove this after implementing the *real* content. (It is just a placeholder for now)
 class Example extends Component {
@@ -68,7 +69,7 @@ export const routes = [
   { name: translate('topology'), slug: '/topology',
     items: [
       { name: translate('control_planes'), slug: '/topology/control_planes', component: ControlPlanes },
-      { name: translate('regions'), slug: '/topology/regions', component: Example },
+      { name: translate('regions'), slug: '/topology/regions', component: Regions },
       { name: translate('services'), slug: '/topology/services', component: Example },
       { name: translate('networks'), slug: '/topology/networks', component: Example },
       { name: translate('servers'), slug: '/topology/servers', component: Example },


### PR DESCRIPTION
Add region page in the topology section.  Introduce caching so that
toggling between topology tabs does not cause a re-load.  Use
componentDidMount instead of componentWillMount for loading data
per the guidance in the react documents:
https://reactjs.org/docs/react-component.html#componentdidmount .
Enable linking to anchors on different pages.