### PR TITLE
Hide unfinished functionality in the Day2 UI (bsc#1105689)

### DIFF
--- a/src/components/CollapsibleTable.js
+++ b/src/components/CollapsibleTable.js
@@ -22,6 +22,7 @@ import { BaseInputModal, ConfirmModal } from './Modals.js';
 import { List, Map } from 'immutable';
 import { byServerNameOrId } from '../utils/Sort.js';
 import { getAllOtherServerIds } from '../utils/ModelUtils.js';
+import { isProduction } from '../utils/ConfigHelper.js';
 
 class CollapsibleTable extends Component {
   constructor(props) {
@@ -105,23 +106,37 @@ class CollapsibleTable extends Component {
     if (role.indexOf('COMPUTE') === -1) { //not compute node
       items = [{
         show: true, key: 'common.details', handleShowModal: this.handleShowMenuServerDetails,
-      }, {
-        show: true, key: 'common.replace', handleShowModal: this.handleShowMenuReplaceServer
       }];
+
+      //if the UI is not in production mode, include menu options that aren't completed yet
+      if(!isProduction()) {
+        items.push({
+          show: true, key: 'common.replace', handleShowModal: this.handleShowMenuReplaceServer
+        });
+      }
     }
     else { //TODO need dynamically show or not show based on the rowData status
-      items = [{
-        show: true, key: 'common.details', handleShowModal: this.handleShowMenuServerDetails
-      }, {
-        show: false, key: 'common.activate', handleShowModal: this.handleShowMenuActivateServer
-      }, {
-        show: true, key: 'common.deactivate', handleShowModal: this.handleShowMenuDeactivateServer
-      }, {
-        show: false, key: 'common.delete', handleShowModal: this.handleShowMenuDeleteServer
-      }, {
-        show: true, key: 'common.replace', handleShowModal: this.handleShowMenuReplaceServer
-      }];
+      items = [
+        {
+          show: true, key: 'common.details', handleShowModal: this.handleShowMenuServerDetails
+        }
+      ];
+
+      if (!isProduction()) {
+        items.push(
+            {
+              show: false, key: 'common.activate', handleShowModal: this.handleShowMenuActivateServer
+            }, {
+              show: true, key: 'common.deactivate', handleShowModal: this.handleShowMenuDeactivateServer
+            }, {
+              show: false, key: 'common.delete', handleShowModal: this.handleShowMenuDeleteServer
+            }, {
+              show: true, key: 'common.replace', handleShowModal: this.handleShowMenuReplaceServer
+            }
+        );
+      }
     }
+
     this.setState({
       showMenu: true, activeRowData: rowData, menuItems: items,
       menuLocation: {x: event.pageX, y: event.pageY}

--- a/src/components/NavMenu.js
+++ b/src/components/NavMenu.js
@@ -17,6 +17,7 @@ import React, { Component } from 'react';
 import { HashRouter as Router, Link } from 'react-router-dom';
 import Route from 'react-router-dom/Route';
 import { translate } from '../localization/localize.js';
+import { isProduction } from '../utils/ConfigHelper.js';
 
 class NavMenu extends Component {
 
@@ -42,15 +43,17 @@ class NavMenu extends Component {
         key={index}
         path={e.slug}
         render={props => {
-          const items = e.items.map((sub, subidx) => (
-            <Route
-              key={subidx}
-              path={sub.slug}
-              children={({match}) => (
-                <Link className={match ? 'active' : ''} to={sub.slug}>{sub.name}</Link>
-              )}
-            />
-          ));
+          const items = e.items.map((sub, subidx) => {
+            if(!(isProduction() && sub.unfinished)) return (
+              <Route
+                key={subidx}
+                path={sub.slug}
+                children={({match}) => (
+                  <Link className={match ? 'active' : ''} to={sub.slug}>{sub.name}</Link>
+                )}
+              />
+            )
+          });
           return (
             <nav>
               {items}

--- a/src/utils/ConfigHelper.js
+++ b/src/utils/ConfigHelper.js
@@ -28,3 +28,14 @@ if (PRODUCTION) {
 export function getAppConfig(key) {
   return config[key];
 }
+
+/**
+ * if the app is in production mode, return true, otherwise return false
+ * @returns {boolean}
+ */
+export function isProduction(){
+  if (PRODUCTION){
+    return true;
+  }
+  return false;
+}

--- a/src/utils/RouteConfig.js
+++ b/src/utils/RouteConfig.js
@@ -23,6 +23,7 @@ import UpdateServers from '../pages/UpdateServers.js';
 import InstallWizard from '../InstallWizard.js';
 import {UpdateServerPages} from '../pages/ReplaceServer/UpdateServerPages.js';
 import ControlPlanes from '../pages/topology/ControlPlanes.js';
+import { isProduction } from './ConfigHelper.js';
 
 // TODO: Remove this after implementing the *real* content. (It is just a placeholder for now)
 class Example extends Component {
@@ -60,32 +61,36 @@ export const routes = [
   { name: translate('services'), slug: '/services',
     items: [
       { name: translate('information'), slug: '/services/info', component: ServiceInfo },
-      { name: translate('packages'), slug: '/services/packages', component: Example },
-      { name: translate('configure'), slug: '/services/configure', component: Example },
+      { name: translate('packages'), slug: '/services/packages', component: Example , unfinished: true},
+      { name: translate('configure'), slug: '/services/configure', component: Example , unfinished: true },
       { name: translate('roles'), slug: '/services/roles', component: ServicesPerRole },
     ]
   },
   { name: translate('topology'), slug: '/topology',
     items: [
       { name: translate('control_planes'), slug: '/topology/control_planes', component: ControlPlanes },
-      { name: translate('regions'), slug: '/topology/regions', component: Example },
-      { name: translate('services'), slug: '/topology/services', component: Example },
-      { name: translate('networks'), slug: '/topology/networks', component: Example },
-      { name: translate('servers'), slug: '/topology/servers', component: Example },
-      { name: translate('server_groups'), slug: '/topology/server-groups', component: Example },
+      { name: translate('regions'), slug: '/topology/regions', component: Example , unfinished: true },
+      { name: translate('services'), slug: '/topology/services', component: Example , unfinished: true },
+      { name: translate('networks'), slug: '/topology/networks', component: Example , unfinished: true },
+      { name: translate('servers'), slug: '/topology/servers', component: Example , unfinished: true },
+      { name: translate('server_groups'), slug: '/topology/server-groups', component: Example , unfinished: true },
     ]
   },
   { name: translate('servers'), slug: '/servers',
     items: [
       { name: translate('common.summary'), slug: '/servers/server-summary', component: ServerSummary },
-      { name: translate('add_server'), slug: '/servers/add-server', component: Example },
-    ]
-  },
-  // Avoid the hassle of creating translations for this disposable code:
-  { name: 'Example', slug: '/example',
-    items: [
-      { name: 'Speedometer', slug: '/example/speedometer', component: SpeedometerTest },
-      { name: 'Alarm Donut', slug: '/example/alarmdonut', component: AlarmDonutTest },
+      { name: translate('add_server'), slug: '/servers/add-server', component: Example , unfinished: true },
     ]
   }
 ];
+
+if(!isProduction()) {
+  routes.push(
+    // Avoid the hassle of creating translations for this disposable code:
+    { name: 'Example', slug: '/example',
+        items: [
+      { name: 'Speedometer', slug: '/example/speedometer', component: SpeedometerTest },
+      { name: 'Alarm Donut', slug: '/example/alarmdonut', component: AlarmDonutTest },
+    ]
+  });
+}


### PR DESCRIPTION
Hides examples, navigation items, and menu items that aren't finished yet from the user when in production mode.