### PR TITLE
Add OpenStack Packages and SUSE Cloud Packages pages

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -313,7 +313,6 @@
     "server_groups": "Server Groups",
     "information": "Information",
     "configure": "Configure",
-    "packages": "Packages",
     "roles": "Roles",
     "endpoints": "Endpoints",
     "add_server": "Add Server",
@@ -502,6 +501,14 @@
     "services.run.status" : "Run Status Playbook",
     "services.status.result" : "Run Status Playbook - {0}",
     "services.cancel.playbook" : "Cancel Playbook",
+
+    "packages.openstack": "OpenStack Packages",
+    "packages.ardana": "SUSE Cloud Packages",
+    "services.header.packages.openstack" : "Installed OpenStack Packages",
+    "services.header.packages.ardana" : "Installed SUSE Cloud Packages",
+    "services.version" : "Version",
+    "services.installed.version" : "Installed Version",
+    "services.available.version" : "Available Version",
 
     "server.replace.heading": "Replace a Server - {0}",
     "server.available.prompt": "Available Servers",

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -509,6 +509,7 @@
     "services.version" : "Version",
     "services.installed.version" : "Installed Version",
     "services.available.version" : "Available Version",
+    "services.package.unavailable" : "Package information is not available",
 
     "server.replace.heading": "Replace a Server - {0}",
     "server.available.prompt": "Available Servers",

--- a/src/pages/ArdanaPackages.js
+++ b/src/pages/ArdanaPackages.js
@@ -1,0 +1,78 @@
+// (c) Copyright 2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+import React, { Component } from 'react';
+import { translate } from '../localization/localize.js';
+import { alphabetically } from '../utils/Sort.js';
+import { fetchJson } from '../utils/RestUtils.js';
+import { LoadingMask } from '../components/LoadingMask.js';
+
+class ArdanaPackages extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      packages: undefined,
+      showLoadingMask: false
+    };
+  }
+
+  componentWillMount() {
+    this.setState({showLoadingMask: true});
+    fetchJson('/api/v1/clm/packages/ardana')
+      .then(responseData => {
+        this.setState({packages: responseData, showLoadingMask: false});
+      });
+  }
+
+  render() {
+    let rows = [];
+    if (this.state.packages) {
+      rows = this.state.packages
+        .sort((a,b) => alphabetically(a.name, b.name))
+        .map((pkg, idx) => {
+          return (
+            <tr key={idx}>
+              <td>{pkg.name}</td>
+              <td>{pkg['version']}</td>
+            </tr>
+          );
+        });
+    }
+
+    return (
+      <div>
+        <LoadingMask show={this.state.showLoadingMask}></LoadingMask>
+        <div className='menu-tab-content'>
+          <div className='header'>{translate('packages.ardana')}</div>
+          <table className='table'>
+            <thead>
+              <tr>
+                <th>{translate('name')}</th>
+                <th>{translate('services.version')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default ArdanaPackages;

--- a/src/pages/ArdanaPackages.js
+++ b/src/pages/ArdanaPackages.js
@@ -18,6 +18,7 @@ import { translate } from '../localization/localize.js';
 import { alphabetically } from '../utils/Sort.js';
 import { fetchJson } from '../utils/RestUtils.js';
 import { LoadingMask } from '../components/LoadingMask.js';
+import { ErrorMessage } from '../components/Messages.js';
 
 class ArdanaPackages extends Component {
 
@@ -25,6 +26,7 @@ class ArdanaPackages extends Component {
     super();
     this.state = {
       packages: undefined,
+      error: undefined,
       showLoadingMask: false
     };
   }
@@ -34,7 +36,30 @@ class ArdanaPackages extends Component {
     fetchJson('/api/v1/clm/packages/ardana')
       .then(responseData => {
         this.setState({packages: responseData, showLoadingMask: false});
+      })
+      .catch((error) => {
+        this.setState({
+          error: {
+            title: translate('default.error'),
+            messages: [translate('services.package.unavailable')]
+          },
+          showLoadingMask: false
+        });
       });
+  }
+
+  renderErrorMessage() {
+    if (this.state.error) {
+      return (
+        <div className='notification-message-container'>
+          <ErrorMessage
+            closeAction={() => this.setState({error: undefined})}
+            title={this.state.error.title}
+            message={this.state.error.messages}>
+          </ErrorMessage>
+        </div>
+      );
+    }
   }
 
   render() {
@@ -54,6 +79,7 @@ class ArdanaPackages extends Component {
 
     return (
       <div>
+        {this.renderErrorMessage()}
         <LoadingMask show={this.state.showLoadingMask}></LoadingMask>
         <div className='menu-tab-content'>
           <div className='header'>{translate('packages.ardana')}</div>

--- a/src/pages/ArdanaPackages.js
+++ b/src/pages/ArdanaPackages.js
@@ -67,9 +67,9 @@ class ArdanaPackages extends Component {
     if (this.state.packages) {
       rows = this.state.packages
         .sort((a,b) => alphabetically(a.name, b.name))
-        .map((pkg, idx) => {
+        .map((pkg) => {
           return (
-            <tr key={idx}>
+            <tr key={pkg.name}>
               <td>{pkg.name}</td>
               <td>{pkg['version']}</td>
             </tr>

--- a/src/pages/OpenStackPackages.js
+++ b/src/pages/OpenStackPackages.js
@@ -1,0 +1,80 @@
+// (c) Copyright 2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+import React, { Component } from 'react';
+import { translate } from '../localization/localize.js';
+import { alphabetically } from '../utils/Sort.js';
+import { fetchJson } from '../utils/RestUtils.js';
+import { LoadingMask } from '../components/LoadingMask.js';
+
+class OpenStackPackages extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      packages: undefined,
+      showLoadingMask: false
+    };
+  }
+
+  componentWillMount() {
+    this.setState({showLoadingMask: true});
+    fetchJson('/api/v1/clm/packages/openstack')
+      .then(responseData => {
+        this.setState({packages: responseData, showLoadingMask: false});
+      });
+  }
+
+  render() {
+    let rows = [];
+    if (this.state.packages) {
+      rows = this.state.packages
+        .sort((a,b) => alphabetically(a.name, b.name))
+        .map((pkg, idx) => {
+          return (
+            <tr key={idx}>
+              <td className='capitalize'>{pkg.name}</td>
+              <td>{pkg.installed.join(', ')}</td>
+              <td>{pkg.available}</td>
+            </tr>
+          );
+        });
+    }
+
+    return (
+      <div>
+        <LoadingMask show={this.state.showLoadingMask}></LoadingMask>
+        <div className='menu-tab-content'>
+          <div className='header'>{translate('packages.openstack')}</div>
+          <table className='table'>
+            <thead>
+              <tr>
+                <th>{translate('name')}</th>
+                <th>{translate('services.installed.version')}</th>
+                <th>{translate('services.available.version')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default OpenStackPackages;

--- a/src/pages/OpenStackPackages.js
+++ b/src/pages/OpenStackPackages.js
@@ -67,9 +67,9 @@ class OpenStackPackages extends Component {
     if (this.state.packages) {
       rows = this.state.packages
         .sort((a,b) => alphabetically(a.name, b.name))
-        .map((pkg, idx) => {
+        .map((pkg) => {
           return (
-            <tr key={idx}>
+            <tr key={pkg.name}>
               <td className='capitalize'>{pkg.name}</td>
               <td>{pkg.installed.join(', ')}</td>
               <td>{pkg.available}</td>

--- a/src/pages/OpenStackPackages.js
+++ b/src/pages/OpenStackPackages.js
@@ -18,6 +18,7 @@ import { translate } from '../localization/localize.js';
 import { alphabetically } from '../utils/Sort.js';
 import { fetchJson } from '../utils/RestUtils.js';
 import { LoadingMask } from '../components/LoadingMask.js';
+import { ErrorMessage } from '../components/Messages.js';
 
 class OpenStackPackages extends Component {
 
@@ -25,6 +26,7 @@ class OpenStackPackages extends Component {
     super();
     this.state = {
       packages: undefined,
+      error: undefined,
       showLoadingMask: false
     };
   }
@@ -34,7 +36,30 @@ class OpenStackPackages extends Component {
     fetchJson('/api/v1/clm/packages/openstack')
       .then(responseData => {
         this.setState({packages: responseData, showLoadingMask: false});
+      })
+      .catch((error) => {
+        this.setState({
+          error: {
+            title: translate('default.error'),
+            messages: [translate('services.package.unavailable')]
+          },
+          showLoadingMask: false
+        });
       });
+  }
+
+  renderErrorMessage() {
+    if (this.state.error) {
+      return (
+        <div className='notification-message-container'>
+          <ErrorMessage
+            closeAction={() => this.setState({error: undefined})}
+            title={this.state.error.title}
+            message={this.state.error.messages}>
+          </ErrorMessage>
+        </div>
+      );
+    }
   }
 
   render() {
@@ -55,6 +80,7 @@ class OpenStackPackages extends Component {
 
     return (
       <div>
+        {this.renderErrorMessage()}
         <LoadingMask show={this.state.showLoadingMask}></LoadingMask>
         <div className='menu-tab-content'>
           <div className='header'>{translate('packages.openstack')}</div>

--- a/src/utils/RouteConfig.js
+++ b/src/utils/RouteConfig.js
@@ -16,6 +16,8 @@
 import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
 import ServiceInfo from '../pages/ServiceInfo';
+import OpenStackPackages from '../pages/OpenStackPackages';
+import ArdanaPackages from '../pages/ArdanaPackages';
 import ServicesPerRole from '../pages/ServicesPerRole';
 import { SpeedometerTest } from '../pages/SpeedometerTest';
 import { AlarmDonutTest } from '../pages/AlarmDonutTest';
@@ -72,7 +74,8 @@ export const routes = [
   { name: translate('services'), slug: '/services',
     items: [
       { name: translate('information'), slug: '/services/info', component: ServiceInfo },
-      { name: translate('packages'), slug: '/services/packages', component: Example , unfinished: true},
+      { name: translate('packages.openstack'), slug: '/services/openstack-packages', component: OpenStackPackages },
+      { name: translate('packages.ardana'), slug: '/services/openstack-ardana', component: ArdanaPackages },
       { name: translate('configure'), slug: '/services/configure', component: Example , unfinished: true },
       { name: translate('roles'), slug: '/services/roles', component: ServicesPerRole },
     ]


### PR DESCRIPTION
SCRD-4309 Added two new pages under the Services menu: OpenStack Packages page and SUSE Cloud Packages page (for Ardana packages)

To test, you can point your shimurl in config.dev.js to Jack's machine at http://192.168.200.88:3000. I'm not sure what's the official name for Ardana is, so I'm using 'SUSE Cloud' for now. I can update if if/when we decide to use a different name.