### PR TITLE
SCRD-4430 Update Servers column in Services Per Role page

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -505,6 +505,7 @@
 
     "services.info" : "Service Information",
     "services.services.per.role" : "Services Per Role",
+    "services.services.per.role.unavailable" : "Services per role information is not available",
     "services.run.status" : "Run Status Playbook",
     "services.status.result" : "Run Status Playbook - {0}",
     "services.cancel.playbook" : "Cancel Playbook",

--- a/src/pages/ServicesPerRole.js
+++ b/src/pages/ServicesPerRole.js
@@ -15,75 +15,117 @@
 
 import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
-import { fetchJson } from '../utils/RestUtils.js';
+import { getInternalModel } from './topology/TopologyUtils.js';
+import { alphabetically } from '../utils/Sort.js';
+import { LoadingMask } from '../components/LoadingMask.js';
+import { ErrorMessage } from '../components/Messages.js';
 
 class ServicesPerRole extends Component {
 
   constructor() {
     super();
     this.state = {
-      model: undefined
+      model: undefined,
+      error: undefined,
+      showLoadingMask: false
     };
   }
 
   componentWillMount() {
-    fetchJson('/api/v1/clm/model')
-      .then(responseData => {
-        this.setState({'model': responseData.inputModel});
+    this.setState({showLoadingMask: true});
+    getInternalModel()
+      .then((yml) => {
+        // Force a re-render if the page is still shown (user may navigate away while waiting)
+        if (this.refs.services_per_role) {
+          this.setState({model: yml, showLoadingMask: false});
+        }
+      })
+      .catch((error) => {
+        this.setState({
+          error: {
+            title: translate('default.error'),
+            messages: [translate('services.services.per.role.unavailable')]
+          },
+          showLoadingMask: false
+        });
       });
   }
 
+  renderErrorMessage() {
+    if (this.state.error) {
+      return (
+        <div className='notification-message-container'>
+          <ErrorMessage
+            closeAction={() => this.setState({error: undefined})}
+            title={this.state.error.title}
+            message={this.state.error.messages}>
+          </ErrorMessage>
+        </div>
+      );
+    }
+  }
+
   render() {
-    let roles = [];
+    let sortedRoles =[];
     if (this.state.model) {
-      this.state.model['control-planes'].map(controlPlane => {
-        const commonServices = controlPlane['common-service-components'];
-        controlPlane.clusters.map(cluster => {
-          const combinedServices = commonServices.concat(cluster['service-components']);
-          roles.push({serverRole: cluster['server-role'], services: combinedServices.sort()});
+      let roles = [];
+      this.state.model['internal']['servers'].map(server => {
+        let serverServices = [];
+        Object.keys(server.services).map(serviceName => {
+          serverServices = serverServices.concat(server.services[serviceName]);
         });
-        controlPlane.resources.map(resource => {
-          const combinedServices = commonServices.concat(resource['service-components']);
-          roles.push({serverRole: resource['server-role'], services: combinedServices.sort()});
+
+        roles.push({
+          serverRole: server.role,
+          serverName: server.name,
+          serverId: server.id,
+          services: serverServices.sort().join(', ')
         });
       });
-      this.state.model['servers'].map(server => {
-        const foundIndex = roles.findIndex(s => s.serverRole === server.role);
+      roles.sort((a,b) => alphabetically(a.serverRole, b.serverRole)).map(role => {
+        const foundIndex = sortedRoles.findIndex(r => r.serverRole === role.serverRole);
         if (foundIndex !== -1) {
-          if (roles[foundIndex].ids) {
-            roles[foundIndex].ids.push(server.id);
-          } else {
-            roles[foundIndex].ids = [server.id];
-          }
+          sortedRoles[foundIndex].serverName.push(role.serverName + ' (' + role.serverId + ')');
+          sortedRoles[foundIndex].serverName.sort();
+        } else {
+          sortedRoles.push({
+            serverRole: role.serverRole,
+            serverName:[role.serverName + ' (' + role.serverId + ')'],
+            services: role.services
+          });
         }
       });
     }
 
-    const rows = roles.map((role, idx) => {
+    const rows = sortedRoles.map((role) => {
       return (
-        <tr key={idx}>
+        <tr key={role.serverName}>
           <td>{role.serverRole}</td>
-          <td className="line-break">{(role.ids) ? role.ids.join('\n') : '-'}</td>
-          <td>{role.services.join(', ')}</td>
+          <td className="line-break">{role.serverName.join('\n')}</td>
+          <td>{role.services}</td>
         </tr>
       );
     });
 
     return (
-      <div className='menu-tab-content'>
-        <div className='header'>{translate('services.services.per.role')}</div>
-        <table className='table'>
-          <thead>
-            <tr>
-              <th width="20%">{translate('role')}</th>
-              <th width="35%">{translate('servers')}</th>
-              <th width="50%">{translate('services')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows}
-          </tbody>
-        </table>
+      <div ref='services_per_role'>
+        {this.renderErrorMessage()}
+        <LoadingMask show={this.state.showLoadingMask}></LoadingMask>
+        <div className='menu-tab-content'>
+          <div className='header'>{translate('services.services.per.role')}</div>
+          <table className='table'>
+            <thead>
+              <tr>
+                <th width="20%">{translate('role')}</th>
+                <th width="35%">{translate('servers')}</th>
+                <th width="50%">{translate('services')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows}
+            </tbody>
+          </table>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Updated the Servers column in Services Per Role page to use the combination of server names and server IDs instead of just server IDs. In order to get the server names, I had to switch to get the data from the output model instead of the input model. Also added error handling and loading mask. 