### PR TITLE
Add servers topology tab

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -306,6 +306,7 @@
 
     "control_planes": "Control Planes",
     "control_plane": "Control Plane: {0}",
+    "control_plane.heading": "Control Plane",
     "clusters": "Clusters",
     "resources": "Resources",
     "load_balancers": "Load Balancers",
@@ -320,6 +321,7 @@
     "information": "Information",
     "configure": "Configure",
     "roles": "Roles",
+    "role": "Role",
     "endpoints": "Endpoints",
     "components": "Components",
     "consumes": "Consumes",
@@ -334,6 +336,9 @@
     "routes": "Routes",
     "vip.for.service": "VIP {0}",
     "vip.address": "{0} (VIP)",
+    "state": "State",
+    "failure_zone": "Failure Zone",
+    "server_roles": "Server Roles",
 
     "vlanid": "VLAN ID",
     "cidr": "CIDR",

--- a/src/pages/topology/ControlPlanes.js
+++ b/src/pages/topology/ControlPlanes.js
@@ -58,7 +58,7 @@ class ControlPlanes extends Component {
 
   render_servers = (servers) => {
     if (servers.length == 0) {
-      return <Fragment> &nbsp; </Fragment>;
+      return <Fragment> </Fragment>;
     }
 
     // Example of creating a link to another page. Probably don't want to do this for real
@@ -140,7 +140,7 @@ class ControlPlanes extends Component {
     for (const service of service_list) {
       const link = <HashLink to={'/topology/services#'+service}>{service}</HashLink>;
 
-      cells = [<td key="x"/>]
+      cells = [<td key="x" className='noborder'/>]
         .concat(cluster_names.map(name => {
           const text = clusters[name]['services'][service] ? link : '';
           return <td key={'c-'+name}>{text}</td>;
@@ -157,20 +157,23 @@ class ControlPlanes extends Component {
       service_rows.push(<tr key={service}>{cells}</tr>);
     }
 
-    const empty_clusters = cluster_names.map((name,idx) => <td key={'c'+idx}/>);
-    const empty_resources = resource_names.map((name,idx) => <td key={'r'+idx}/>);
+    const empty_clusters = cluster_names.map((name,idx) => <td key={'c'+idx} className='noborder'/>);
+    const empty_resources = resource_names.map((name,idx) => <td key={'r'+idx} className='noborder'/>);
 
-    // Generate the rows containing load balancer name/addresses
-    cells = [<td key="x"/>]
-      .concat(empty_clusters)
-      .concat(empty_resources)
-      .concat(lb_names.map(name => {
-        const text = load_balancers[name]['external-name'] || '';
-        return <td key={'l-'+name}>{text}</td>;
-      }));
-    const lb_name_row = (<tr key="lb-name-row">{cells}</tr>);
+    let lb_name_row;
+    if (lb_names.length > 0) {
+      // Generate the rows containing load balancer name/addresses
+      cells = [<td key="x" className='noborder'/>]
+        .concat(empty_clusters)
+        .concat(empty_resources)
+        .concat(lb_names.map(name => {
+          const text = load_balancers[name]['external-name'] || '';
+          return <td key={'l-'+name}>{text}</td>;
+        }));
+      lb_name_row = (<tr key="lb-name-row">{cells}</tr>);
+    }
 
-    cells = [<td key="x"/>]
+    cells = [<td key="x" className='noborder' />]
       .concat(empty_clusters)
       .concat(empty_resources)
       .concat(lb_names.map(name => {
@@ -210,13 +213,13 @@ class ControlPlanes extends Component {
         <div className='header'>{translate('control_plane', cp_name)}</div>
         <table className='table'>
           <thead><tr>
-            <th />
+            <th className='noborder'/>
             <th colSpan={num_clusters}>{translate('clusters')}</th>
             <th colSpan={num_resources}>{translate('resources')}</th>
             <th colSpan={num_load_balancers}>{translate('load_balancers')}</th>
           </tr></thead>
           <tbody>
-            <tr key="header_row"><td>&nbsp;</td>{names}</tr>
+            <tr className='heading' key="header_row"><td className='noborder'/>{names}</tr>
             {service_rows}
             {lb_name_row}
             {lb_address_row}

--- a/src/pages/topology/ControlPlanes.js
+++ b/src/pages/topology/ControlPlanes.js
@@ -208,7 +208,7 @@ class ControlPlanes extends Component {
     });
 
     return (
-      <div key={cp_name} className='menu-tab-content'>
+      <div key={cp_name} className='menu-tab-content topology'>
         <a id={cp_name}/>
         <div className='header'>{translate('control_plane', cp_name)}</div>
         <table className='table'>

--- a/src/pages/topology/Networks.js
+++ b/src/pages/topology/Networks.js
@@ -109,8 +109,8 @@ class Networks extends Component {
       </tr>);
     }
 
-    const clusters_hdr = cluster_names.map(e => <th key={e}>{e}</th>);
-    const resources_hdr = resource_names.map(e => <th key={e}>{e}</th>);
+    const clusters_hdr = cluster_names.map(e => <td key={e}>{e}</td>);
+    const resources_hdr = resource_names.map(e => <td key={e}>{e}</td>);
 
     return (
       <Fragment key={cp_name}>
@@ -122,13 +122,13 @@ class Networks extends Component {
               <th colSpan={clusters_hdr.length}>{translate('clusters')}</th>
               <th colSpan={resources_hdr.length}>{translate('resources')}</th>
             </tr>
-            <tr>
-              <th />
+          </thead>
+          <tbody>
+            <tr className='heading'>
+              <td/>
               {clusters_hdr}
               {resources_hdr}
             </tr>
-          </thead>
-          <tbody>
             {table_rows}
           </tbody>
         </table>
@@ -248,7 +248,7 @@ class Networks extends Component {
         }
 
         if (subtable) {
-          network_cell.push(<table key='tbl'><tbody>{subtable}</tbody></table>);
+          network_cell.push(<table className='nested-table noborder' key='tbl'><tbody>{subtable}</tbody></table>);
         }
 
         cells.push(<td key="nets">{network_cell}</td>);

--- a/src/pages/topology/Networks.js
+++ b/src/pages/topology/Networks.js
@@ -385,7 +385,7 @@ class Networks extends Component {
       <div ref="networks" className='wizard-page'>
         <LoadingMask show={!this.state.model && !this.state.errorMessage}/>
         <div className='wizard-content'>
-          <div className='menu-tab-content'>
+          <div className='menu-tab-content topology'>
             {summaries}
             {this.state.model && this.render_network_groups()}
           </div>

--- a/src/pages/topology/Regions.js
+++ b/src/pages/topology/Regions.js
@@ -116,7 +116,7 @@ class Regions extends Component {
 
 
     return (
-      <div className='menu-tab-content'>
+      <div className='menu-tab-content topology'>
         <table className='table'>
           <thead><tr>{header_row}</tr></thead>
           <tbody>

--- a/src/pages/topology/ServerGroups.js
+++ b/src/pages/topology/ServerGroups.js
@@ -1,0 +1,237 @@
+// (c) Copyright 2017-2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+import React, { Component } from 'react';
+import { HashLink } from 'react-router-hash-link';
+import { translate } from '../../localization/localize.js';
+import '../../styles/deployer.less';
+import { getInternalModel } from './TopologyUtils.js';
+import { ErrorBanner } from '../../components/Messages';
+import { LoadingMask } from '../../components/LoadingMask';
+import { byProperty } from '../../utils/Sort.js';
+
+/*
+ * This class is a JavaScript implementation of the script
+ * ardana_configurationprocessor/plugins/builders/HTMLDiagram/ServerGroups.py
+ * in the config processor
+ */
+class ServerGroups extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      model: undefined,
+      errorMessage: undefined,
+    };
+
+  }
+
+  componentDidMount() {
+
+    getInternalModel()
+      .then((yml) => {
+
+        // Force a re-render if the page is still shown (user may navigate away while waiting)
+        if (this.refs.server_groups)
+          this.setState({
+            model: yml});
+      })
+      .catch((error) => {
+        this.setState({
+          errorMessage: error.toString(),
+        });
+      });
+  }
+
+  // Count the number of descendent groups of the given group that are "leafs" (have no descendents)
+  // Note that the 'child-count' field in each group is not used in this calculation since it is
+  // populated incorrectly -- a group with no children has a child-count of 1.
+  countLeafs = (group) => {
+    let sum = 0;
+    let toCount = [ group ];
+    while (toCount.length > 0) {
+      const g = toCount.shift();
+      if (g.groups && g.groups.length > 0) {
+        toCount = toCount.concat(g.groups);
+      } else {
+        sum += 1;
+      }
+    }
+    return sum;
+  }
+
+  renderServerGroups = (groups) => {
+    // The groups array supplied here should be in the proper order for presenting
+
+    // Build a set of all network groups used in this server group
+    //   and a set of all server roles used by servers in this server group
+    let net_groups = new Set();
+    let roles = new Set();
+    for (const g of groups) {
+      for (const net_group of Object.keys(g['network-groups'] || {})) {
+        net_groups.add(net_group);
+      }
+
+      for (const server of Object.values(g['servers'] || [])) {
+        roles.add(server.role);
+      }
+    }
+
+    const countedGroups = [].concat(groups);
+    countedGroups.forEach(g => g.leafs = this.countLeafs(g));
+
+    // Create header row containing server group names, with appropriate row/col spans
+    let cells = [ <td key="x"/> ].concat(countedGroups.map(g => (
+      <td key={g.name} className='heading' colSpan={g.leafs}>{g.name}</td>
+    )));
+
+    let rows = [ <tr key={groups[0].name}>{cells}</tr> ];
+
+    // Add the network group information
+    let addedHeader = false;
+    for (const net_group of Array.from(net_groups).sort()) {
+      let cells = [];
+
+      // Add a header row before the detail lines
+      if (! addedHeader) {
+        const networks = translate('networks');
+
+        cells = [<td className='sub-heading' key="c1">{translate('network.groups')}</td>]
+          .concat(countedGroups.map((g) => <td key={g.name} className='sub-heading' colSpan={g.leafs}>{networks}</td>));
+
+        rows.push(<tr key="nh">{cells}</tr>);
+        addedHeader = true;
+      }
+
+      cells = [<td key="c1"><HashLink to={'/topology/networks#'+net_group}>{net_group}</HashLink></td>]
+        .concat(countedGroups.map(g => {
+          const name = g['network-groups'][net_group];
+          const link = name ? <HashLink to={'/topology/networks#'+name}>{name}</HashLink> : undefined;
+          return <td key={g.name} colSpan={g.leafs}>{link}</td>;
+        }));
+
+      rows.push(<tr key={net_group}>{cells}</tr>);
+    }
+
+    // Add the server role information
+    addedHeader = false;
+    for (const role of Array.from(roles).sort()) {
+      let cells = [];
+
+      // Add a header row before the detail lines
+      if (! addedHeader) {
+        const servers = translate('servers');
+
+        cells = [<td className='sub-heading' key="c1">{translate('server_roles')}</td>]
+          .concat(countedGroups.map((g) => <td className='sub-heading' key={g.name} colSpan={g.leafs}>{servers}</td>));
+
+        rows.push(<tr key="sh">{cells}</tr>);
+        addedHeader = true;
+      }
+
+      cells = [<td key="c1"><HashLink to={'/topology/roles#'+role}>{role}</HashLink></td>]
+        .concat(countedGroups.map(g => {
+
+          let contents;
+          if (g.servers) {
+            contents = g.servers
+              .filter(s => s.role === role)
+              .sort()
+              .map(s => (
+                <div key={s.id}><HashLink to={'/topology/servers#'+s.id}>{s.id}</HashLink> ({s.hostname})</div>));
+          }
+
+          return <td key={g.name} colSpan={g.leafs}>{contents}</td>;
+        }));
+
+      rows.push(<tr key={role}>{cells}</tr>);
+    }
+
+    // rowSpan += Object.keys(roles).length() > 0 ? Object.keys(roles).length() + 1 : 0;
+
+
+    return rows;
+  }
+
+  render () {
+
+    let groupTable;
+    if (this.state.model) {
+
+      const serverGroups = this.state.model['internal']['server-groups'];
+
+      // Server groups are structured like a tree, with possibly many
+      // levels of nesting, but the model does not plainly identify which
+      // server group(s) is at the top of the tree. In order to determine
+      // this, all server groups are searched, and any server group that
+      // does not appear as a child to some other server group must be
+      // at the top of the tree.
+
+      // Find all server groups that are children of other group(s)
+      let childGroups = new Set();
+      for (const group of Object.values(serverGroups)) {
+        for (const child of group['server-groups'] || []) {
+          childGroups.add(child);
+        }
+      }
+
+      // The top-level groups are all groups that do not appear in childGroups
+      const topGroups = Object.values(serverGroups)
+        .filter(group => ! childGroups.has(group.name))
+        .sort(byProperty('name'));
+
+      // Table rows to put into the groupTable
+      let rows = [];
+
+      // Repeatedly descend into each level of the tree and generate table rows
+      let groups = topGroups;
+      while(groups.length > 0) {
+        rows = rows.concat(this.renderServerGroups(groups));
+
+        let next_generation = [];
+        for (const group of groups) {
+          let subgroups = group['groups'] || [];
+          subgroups.sort(byProperty('name'));
+          next_generation = next_generation.concat(subgroups);
+        }
+
+        groups = next_generation;
+      }
+
+      groupTable = (
+        <table className='table'>
+          <tbody>
+            {rows}
+          </tbody>
+        </table>
+      );
+    }
+
+    return (
+      <div ref="server_groups" className='wizard-page'>
+        <LoadingMask show={!this.state.model && !this.state.errorMessage}/>
+        <div className='wizard-content'>
+          <div className='menu-tab-content'>
+            {groupTable}
+          </div>
+        </div>
+        <div className='banner-container'>
+          <ErrorBanner message={this.state.errorMessage} show={this.state.errorMessage !== undefined} />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ServerGroups;

--- a/src/pages/topology/ServerGroups.js
+++ b/src/pages/topology/ServerGroups.js
@@ -110,7 +110,7 @@ class ServerGroups extends Component {
         cells = [<td className='sub-heading' key="c1">{translate('network.groups')}</td>]
           .concat(countedGroups.map((g) => <td key={g.name} className='sub-heading' colSpan={g.leafs}>{networks}</td>));
 
-        rows.push(<tr key="nh">{cells}</tr>);
+        rows.push(<tr key={'nh'+groups[0].name}>{cells}</tr>);
         addedHeader = true;
       }
 
@@ -136,7 +136,7 @@ class ServerGroups extends Component {
         cells = [<td className='sub-heading' key="c1">{translate('server_roles')}</td>]
           .concat(countedGroups.map((g) => <td className='sub-heading' key={g.name} colSpan={g.leafs}>{servers}</td>));
 
-        rows.push(<tr key="sh">{cells}</tr>);
+        rows.push(<tr key={'sh'+groups[0].name}>{cells}</tr>);
         addedHeader = true;
       }
 
@@ -157,9 +157,6 @@ class ServerGroups extends Component {
 
       rows.push(<tr key={role}>{cells}</tr>);
     }
-
-    // rowSpan += Object.keys(roles).length() > 0 ? Object.keys(roles).length() + 1 : 0;
-
 
     return rows;
   }

--- a/src/pages/topology/ServerGroups.js
+++ b/src/pages/topology/ServerGroups.js
@@ -219,7 +219,7 @@ class ServerGroups extends Component {
       <div ref="server_groups" className='wizard-page'>
         <LoadingMask show={!this.state.model && !this.state.errorMessage}/>
         <div className='wizard-content'>
-          <div className='menu-tab-content'>
+          <div className='menu-tab-content topology'>
             {groupTable}
           </div>
         </div>

--- a/src/pages/topology/Services.js
+++ b/src/pages/topology/Services.js
@@ -183,7 +183,7 @@ class Services extends Component {
             </tr>);
           });
 
-          endpoints_cell = (<table className='endpoints'><tbody>{rows}</tbody></table>);
+          endpoints_cell = (<table className='endpoints nested-table noborder'><tbody>{rows}</tbody></table>);
         }
 
         let cells = [];

--- a/src/pages/topology/Services.js
+++ b/src/pages/topology/Services.js
@@ -220,7 +220,7 @@ class Services extends Component {
       <div ref="services" className='wizard-page'>
         <LoadingMask show={!this.state.model && !this.state.errorMessage}/>
         <div className='wizard-content'>
-          <div className='menu-tab-content'>
+          <div className='menu-tab-content topology'>
             {this.state.model && this.render_summary()}
             {this.state.model && this.render_services()}
           </div>

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -110,6 +110,7 @@ p {
     }
   }
   tbody > tr > td {
+    border-top: none;
     padding-left: 1em;
   }
 

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -101,7 +101,7 @@ p {
       background: linear-gradient(to bottom, @table-header-gradient-color 0%, @table-header-color 100%);
       font-weight: bold;
       line-height: 2.8em;
-      padding: 0 0 0 1em;
+      padding: 0 1em;
     }
   }
   tbody > tr {
@@ -110,7 +110,6 @@ p {
     }
   }
   tbody > tr > td {
-    border-top: none;
     padding-left: 1em;
   }
 

--- a/src/styles/pages/Topology.less
+++ b/src/styles/pages/Topology.less
@@ -13,6 +13,10 @@
 * limitations under the License.
 **/
 
+.noborder {
+  border: none;
+}
+
 .menu-tab-content {
   .available {
     font-weight: bold;
@@ -24,12 +28,41 @@
   }
 
   .endpoints {
+    // Avoid extra level of indentation on the Left of nested endpoints table
+    tbody > tr > td:first-child {
+      padding-left: 0px;
+    }
     .role {
       width: 150px;
     }
     .port {
       width: 100px;
     }
+  }
+
+  table {
+      border:1px solid @sb-gray-200;
+      padding:5;
+      border-spacing:5;
+      width: inherit;
+  }
+
+  td,th {
+      border:1px solid @sb-gray-200;
+      padding:5;
+      border-spacing:5;
+
+      &.noborder {
+        .noborder;
+      }
+  }
+
+
+  .title {
+      border:0px ;
+      padding:0;
+      margin-left:10;
+      font-weight:bold;
   }
 
   .label-cell {
@@ -45,7 +78,17 @@
   }
 
   .comp-dtl {
-    text-indent: 110px;
+    text-indent: 25px;
+  }
+
+  .heading {
+    font-weight: bold;
+    font-style: italic;
+  }
+
+  .sub-heading {
+    font-style: italic;
+    padding-top: 1em;
   }
 
   // Fix the width of the headers of the leading columns of the nested table 
@@ -69,6 +112,17 @@
   }
 
   .nested-table {
+    &.noborder {
+      .noborder;
+    }
+
+    table {
+      border: none;
+    }
+
     padding-left: 0px;
+    td {
+      border: none
+    }
   }
 }

--- a/src/styles/pages/Topology.less
+++ b/src/styles/pages/Topology.less
@@ -17,7 +17,7 @@
   border: none;
 }
 
-.menu-tab-content {
+.menu-tab-content.topology {
   .available {
     font-weight: bold;
   }

--- a/src/utils/RouteConfig.js
+++ b/src/utils/RouteConfig.js
@@ -28,6 +28,7 @@ import ControlPlanes from '../pages/topology/ControlPlanes.js';
 import Regions from '../pages/topology/Regions.js';
 import Services from '../pages/topology/Services.js';
 import Network from '../pages/topology/Networks.js';
+import ServerGroups from '../pages/topology/ServerGroups.js';
 import { isProduction } from './ConfigHelper.js';
 
 import AddServers from '../pages/AddServers.js';
@@ -88,8 +89,8 @@ export const routes = [
       { name: translate('regions'), slug: '/topology/regions', component: Regions },
       { name: translate('services'), slug: '/topology/services', component: Services },
       { name: translate('networks'), slug: '/topology/networks', component: Network },
-      { name: translate('servers'), slug: '/topology/servers', component: Example , unfinished: true },
-      { name: translate('server_groups'), slug: '/topology/server-groups', component: Example , unfinished: true },
+      { name: translate('server_groups'), slug: '/topology/server-groups', component: ServerGroups , unfinished: true },
+      { name: translate('roles'), slug: '/topology/roles', component: Example , unfinished: true },
     ]
   },
   { name: translate('servers'), slug: '/servers',


### PR DESCRIPTION
Add servers tab to the topology page.
Implement styling changes to clarify relationships, making the pages
  more similar to the original versions from the config processor.