### PR TITLE
SCRD-3478 Update OpenStack and Ardana Packages pages with new API

### DIFF
--- a/src/pages/ArdanaPackages.js
+++ b/src/pages/ArdanaPackages.js
@@ -35,9 +35,9 @@ class ArdanaPackages extends Component {
 
   componentWillMount() {
     this.setState({showLoadingMask: true});
-    fetchJson('/api/v1/clm/packages/ardana')
+    fetchJson('/api/v1/clm/packages')
       .then(responseData => {
-        this.setState({packages: responseData, showLoadingMask: false});
+        this.setState({packages: responseData.cloud_installed_packages, showLoadingMask: false});
       })
       .catch((error) => {
         this.setState({
@@ -74,11 +74,11 @@ class ArdanaPackages extends Component {
       rows = this.state.packages
         .sort((a,b) => alphabetically(a.name, b.name))
         .map((pkg) => {
-          if (pkg.name.includes(this.state.searchText) || pkg['version'].includes(this.state.searchText)) {
+          if (pkg.name.includes(this.state.searchText) || pkg.versions.join(', ').includes(this.state.searchText)) {
             return (
               <tr key={pkg.name}>
                 <td>{pkg.name}</td>
-                <td>{pkg['version']}</td>
+                <td>{pkg.versions.join(', ')}</td>
               </tr>
             );
           }

--- a/src/pages/OpenStackPackages.js
+++ b/src/pages/OpenStackPackages.js
@@ -33,9 +33,9 @@ class OpenStackPackages extends Component {
 
   componentWillMount() {
     this.setState({showLoadingMask: true});
-    fetchJson('/api/v1/clm/packages/openstack')
+    fetchJson('/api/v1/clm/packages')
       .then(responseData => {
-        this.setState({packages: responseData, showLoadingMask: false});
+        this.setState({packages: responseData.openstack_venv_packages, showLoadingMask: false});
       })
       .catch((error) => {
         this.setState({
@@ -71,7 +71,7 @@ class OpenStackPackages extends Component {
           return (
             <tr key={pkg.name}>
               <td className='capitalize'>{pkg.name}</td>
-              <td>{pkg.installed.join(', ')}</td>
+              <td>{pkg.installed.length > 0 ? pkg.installed.join(', ') : '-'}</td>
               <td>{pkg.available}</td>
             </tr>
           );


### PR DESCRIPTION
Updated the OpenStack Packages page and the SUSE OpenStack Cloud Packages page with the new API. This change depends on these backend changes which implement the new API: https://gerrit.suse.provo.cloud/#/c/4708 and https://gerrit.suse.provo.cloud/#/c/4709. Please do not merge this change until the backend changes were merged.