### PR TITLE
SCRD-5069 Correctly map status playbook for some services

### DIFF
--- a/src/pages/ServiceInfo.js
+++ b/src/pages/ServiceInfo.js
@@ -91,8 +91,30 @@ class ServiceInfo extends Component {
     this.setState({showActionMenu: false});
   }
 
+  getPlaybookName = () => {
+    let name;
+    switch(this.state.selectedService) {
+    case 'ardana':
+      name = 'ardana-service';
+      break;
+    case 'cinderv2':
+    case 'cinderv3':
+      name = 'cinder';
+      break;
+    case 'kronos':
+      name = 'logging';
+      break;
+    case 'opsconsole':
+      name = 'ops-console';
+      break;
+    default:
+      name = this.state.selectedService;
+    }
+    return name + '-status';
+  }
+
   showRunStatusPlaybookModal = () => {
-    const playbookName = this.state.selectedService + '-status';
+    const playbookName = this.getPlaybookName();
     this.setState({
       showActionMenu: false,
       showRunStatusPlaybookModal: true,


### PR DESCRIPTION
Map the following services to the right playbook: 
1. Ardana --> ardana-service-status.yml
2. Cinderv2 and Cinderv3 --> cinder-status.yml
3. Kronos --> logging-status.yml
4. Opsconsole -> ops-console-status.yml