### PR TITLE
SCRD-4911 Add SSH Passphrase field to OS provision page

### DIFF
--- a/src/styles/components/serverprovision.less
+++ b/src/styles/components/serverprovision.less
@@ -14,14 +14,15 @@
 **/
 .server-provision {
   .password-container {
-    width: 25%;
+    width: 40%;
     margin-bottom: 1.5em;
     .detail-line {
       width: 100%;
       display: flex;
       margin-bottom: 0.8em;
       .detail-heading {
-        margin-right: 1.5em;
+        min-height: 25px;
+        width: 25%;
       }
       .detail-field {
         margin-left: 0.3em;
@@ -29,7 +30,7 @@
       .input-body {
         position: relative;
         top: -4px;
-        min-width: 20em;
+        min-width: 30em;
       }
     }
   }
@@ -42,4 +43,9 @@
 
 .banner-container {
   margin-top: 2em;
+  &.no-margin-bottom {
+    .alert {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/src/styles/components/serverutils.less
+++ b/src/styles/components/serverutils.less
@@ -185,6 +185,6 @@
   cursor: pointer;
   position: relative;
   left: -27px;
-  top: 2px;
+  top: 4px;
   color: @info-link-color;
 }


### PR DESCRIPTION
Added the SSH Passphrase field to the Day0 UI's OS provision page so that the user can provide the passphrase when it is required for the OS provisioning step. 

To test: 
1. ssh to Oak's deployer
2. cd to ~/.ssh directory
3. rename the original id_rsa and id_rsa.pub files to something else, for example 'mv id_rsa id_rsa.save' and 'mv id_rsa.pub id_rsa.pub.save'
4. rename the id_rsa.passphrase and id_rsa.pub.passphrase files to id_rsa and id_rsa.pub
5. restart the ardana service, i.e. 'sudo systemctl restart ardana-service'

Oak in its current state does not have the ssh passphrase setup. The above steps sets up the ssh process to require a passphrase. After these steps, the SSH Passphrase field will show up on the page below the Password field. If you enter an incorrect passphrase, you would get an error banner. If you enter the correct passphrase 'gone2far', the OS provisioning process should start. 

After you're done testing, please rename the id_rsa* files back to their original names and restart the ardana service.