### PR TITLE
Improve replace controller dialog

### DIFF
--- a/src/components/CollapsibleTable.js
+++ b/src/components/CollapsibleTable.js
@@ -309,13 +309,16 @@ class CollapsibleTable extends Component {
 
   renderReplaceServerModal() {
     let title = translate('server.replace.heading', this.state.activeRowData.id);
+    let newProps = { ...this.props };
+    newProps.knownServers = [].concat(this.props.manualServers || []).concat(this.props.autoServers || []);
+
     return (
       <BaseInputModal
         show={this.state.showReplaceServerModal} className='edit-details-dialog'
         onHide={this.handleCancelReplaceServer} title={title}>
         <ReplaceServerDetails
           cancelAction={this.handleCancelReplaceServer} doneAction={this.handleDoneReplaceServer}
-          data={this.state.activeRowData} {...this.props}>
+          data={this.state.activeRowData} { ...newProps }>
         </ReplaceServerDetails>
       </BaseInputModal>
     );

--- a/src/components/ReplaceServerDetails.js
+++ b/src/components/ReplaceServerDetails.js
@@ -51,12 +51,6 @@ class ReplaceServerDetails extends Component {
 
   // This should be componentDidMOunt, since reactjs has deprecated ComponentWillMount
   componentWillMount() {
-    if(this.props.data) {
-      // the original data
-      this.data = JSON.parse(JSON.stringify(this.props.data));
-
-    }
-
     fetchJson('/api/v1/clm/user')
       .then(responseData => {
         this.setState({
@@ -84,10 +78,13 @@ class ReplaceServerDetails extends Component {
   }
 
   handleDone = () => {
-    this.data['mac-addr'] = this.state.replaceData.get('mac-addr');
-    this.data['ilo-ip'] = this.state.replaceData.get('ilo-ip');
-    this.data['ilo-user'] = this.state.replaceData.get('ilo-user');
-    this.data['ilo-password'] = this.state.replaceData.get('ilo-password');
+
+    let data = {};
+
+    data['mac-addr'] = this.state.replaceData.get('mac-addr');
+    data['ilo-ip'] = this.state.replaceData.get('ilo-ip');
+    data['ilo-user'] = this.state.replaceData.get('ilo-user');
+    data['ilo-password'] = this.state.replaceData.get('ilo-password');
 
     let theProps = {
       wipeDisk : this.state.isWipeDiskChecked,
@@ -104,15 +101,15 @@ class ReplaceServerDetails extends Component {
     if(this.state.selectedServerId) {
       theProps.selectedServerId = this.state.selectedServerId;
       // if it is an existing server discovered or added, use its uid
-      this.data['uid'] = this.state.replaceData.get('uid');
+      data['uid'] = this.state.replaceData.get('uid');
     }
     else {
       // user input new mac-addr and ilo info
       // generate a new uid
-      this.data.uid = genUID();
+      data.uid = genUID();
     }
 
-    this.props.doneAction(this.data, theProps);
+    this.props.doneAction(data, theProps);
   }
 
   handleInputChange = (e, isValid, props) => {

--- a/src/components/ReplaceServerDetails.js
+++ b/src/components/ReplaceServerDetails.js
@@ -28,6 +28,8 @@ import HelpText from '../components/HelpText.js';
 import { Map, fromJS } from 'immutable';
 import {fetchJson} from '../utils/RestUtils.js';
 
+const Fragment = React.Fragment;
+
 class ReplaceServerDetails extends Component {
   constructor(props) {
     super(props);
@@ -226,25 +228,6 @@ class ReplaceServerDetails extends Component {
     );
   }
 
-  renderText(title, value) {
-    return (
-      <div className='detail-line'>
-        <div className='detail-heading'>{translate(title)}</div>
-        <div className='info-body'>{value}</div>
-      </div>
-    );
-  }
-
-  renderOsPasswordInput() {
-    return (
-      <InputLine
-        isRequired={this.state.isInstallOsChecked} inputName={'osInstallPassword'}
-        inputType={'password'} label={'server.pass.prompt'}
-        inputValue={this.state.osInstallPassword || ''}
-        inputAction={this.handleOsPasswordChange}/>
-    );
-  }
-
   renderAvailableServersDropDown() {
     let emptyOptProps = {
       label: translate('server.please.select'),
@@ -301,6 +284,24 @@ class ReplaceServerDetails extends Component {
     );
   }
 
+  renderOSUserPass() {
+    if (this.state.isInstallOsChecked) {
+      return (
+        <Fragment>
+          <div className='detail-line'>
+            <div className='detail-heading'>{translate('server.user.prompt')}</div>
+            <div className='info-body'>{this.state.osInstallUsername}</div>
+          </div>
+          <InputLine
+            isRequired={this.state.isInstallOsChecked} inputName={'osInstallPassword'}
+            inputType={'password'} label={'server.pass.prompt'}
+            inputValue={this.state.osInstallPassword || ''}
+            inputAction={this.handleOsPasswordChange}/>
+        </Fragment>);
+    }
+  }
+
+
   renderServerContent() {
     return (
       <div>
@@ -319,9 +320,7 @@ class ReplaceServerDetails extends Component {
           <input className='replace-options' type='checkbox' value='installos'
             checked={this.state.isInstallOsChecked} onChange={this.handleInstallOsCheck}/>
           {translate('common.installos')}
-          {this.state.isInstallOsChecked &&
-            this.renderText('server.user.prompt', this.state.osInstallUsername)}
-          {this.state.isInstallOsChecked && this.renderOsPasswordInput()}
+          {this.renderOSUserPass()}
         </div>
         <div className='server-details-container'>
           <input className='replace-options' type='checkbox' value='wipedisk'

--- a/src/components/ReplaceServerDetails.js
+++ b/src/components/ReplaceServerDetails.js
@@ -115,10 +115,6 @@ class ReplaceServerDetails extends Component {
     this.props.doneAction(this.data, theProps);
   }
 
-  handleCancel = () => {
-    this.props.cancelAction();
-  }
-
   handleInputChange = (e, isValid, props) => {
     this.updateFormValidity(props, isValid);
     let value = e.target.value;
@@ -226,27 +222,26 @@ class ReplaceServerDetails extends Component {
     );
   }
 
-  renderDetailsTable() {
-    let rows = [];
-    let sections = [
-      {'role': this.data.role, 'ip-addr': this.data['ip-addr']},
-      {'server-group': this.data['server-group'], 'nic-mapping': this.data['nic-mapping']},
-      {'mac-addr': this.data['mac-addr'], 'ilo-ip': this.data['ilo-ip']},
-      {'ilo-user': this.data['ilo-user'], 'ilo-password': this.data['ilo-password']},
-    ];
-    sections.forEach((section, idx) => {
-      let keys = Object.keys(section);
-      rows.push(
-        <tr key={idx}>
-          <th>{translate('replace.server.details.' + keys[0])}</th>
-          <td>{keys[0].indexOf('password') !== -1  ? maskPassword(section[keys[0]]) : section[keys[0]]}</td>
-          <th>{translate('replace.server.details.' + keys[1])}</th>
-          <td>{keys[1].indexOf('password') !== -1 ? maskPassword(section[keys[1]]) : section[keys[1]]}</td>
-        </tr>);
-    });
+  // Helper function to create a pair of th and td entries with the given name
+  labelField = (name) => {
+    return (
+      <Fragment>
+        <th>{translate('replace.server.details.'+name)}</th>
+        <td>{this.props.data[name]}</td>
+      </Fragment>);
+  }
+  renderDetailsTable = () => {
     return (
       <table className='table table-condensed'>
-        <tbody>{rows}</tbody>
+        <tbody>
+          <tr>{this.labelField('role')}{this.labelField('ip-addr')}</tr>
+          <tr>{this.labelField('server-group')}{this.labelField('nic-mapping')}</tr>
+          <tr>{this.labelField('mac-addr')}{this.labelField('ip-addr')}</tr>
+          <tr>{this.labelField('ilo-user')}
+            <th>{translate('replace.server.details.ilo-password')}</th>
+            <td>{maskPassword(this.props.data['ilo-password'])}</td>
+          </tr>
+        </tbody>
       </table>
     );
   }
@@ -347,7 +342,7 @@ class ReplaceServerDetails extends Component {
     return (
       <div className='btn-row input-button-container'>
         <ActionButton type='default'
-          clickAction={this.handleCancel} displayLabel={translate('cancel')}/>
+          clickAction={this.props.cancelAction} displayLabel={translate('cancel')}/>
         <ActionButton
           isDisabled={!this.isFormInputValid()}
           clickAction={this.handleDone} displayLabel={translate('common.replace')}/>

--- a/src/utils/ModelUtils.js
+++ b/src/utils/ModelUtils.js
@@ -138,29 +138,6 @@ export function getModelIPAddresses (model, excludeIPAddr) {
   return ipAddresses;
 }
 
-// get all available server ids which are not in the model
-export function getAvailableServerIds (model, autoServers, manualServers) {
-  let modelUids= model.getIn(['inputModel','servers'])
-    .map(server => server.get('uid') || server.get('id')).toJS();
-
-  let allAvailableServers = [];
-  if (autoServers && autoServers.length > 0) {
-    allAvailableServers = allAvailableServers.concat(autoServers);
-  }
-  if(manualServers && manualServers.length > 0) {
-    allAvailableServers = allAvailableServers.concat(manualServers);
-  }
-
-  // all the servers that don't belong to model
-  let servers = allAvailableServers.filter((server) => {
-    return (!modelUids.includes(server.uid));
-  });
-
-  let retServerIds = servers.map(server => server.id);
-
-  return retServerIds;
-}
-
 export function getMacIPMIAddrObjs(autoServers, manualServers) {
   let allAvailableServers = [];
   if (autoServers && autoServers.length > 0) {


### PR DESCRIPTION
Before this change the replace controller dialog had a number of sub-optimal constructs including copying props into state, using class variables to hold state, and so on. The form would also trigger many unnecessary renders.
Removed all class variables and copying of props, and improved the handling of state to minimize renders.