### PR TITLE
SCRD-4431 Add error message for keystone unavailable case

### DIFF
--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -137,6 +137,8 @@ class LoginModal extends Component {
           this.setState({errorMsg: translate('login.invalid')});
         } else if (error.status == 403) {
           this.setState({errorMsg: translate('login.unprivileged')});
+        } else if (error.status == 503) {
+          this.setState({errorMsg: translate('login.keystone.error')});
         } else {
           this.setState({errorMsg: translate('login.error', error)});
         }

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -72,6 +72,7 @@
     "login.placeholder.password": "Enter your password...",
     "login.invalid": "Invalid username or password",
     "login.unprivileged": "Insufficient privileges",
+    "login.keystone.error": "Unable to establish connection to Keystone service",
     "login.error": "Login error: {0}",
 
     "install.intro.message.body1": "You are about to install a new cloud.",

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -89,6 +89,8 @@ class LoginPage extends Component {
           this.setState({errorMsg: translate('login.invalid')});
         } else if (error.status == 403) {
           this.setState({errorMsg: translate('login.unprivileged')});
+        } else if (error.status == 503) {
+          this.setState({errorMsg: translate('login.keystone.error')});
         } else {
           this.setState({errorMsg: translate('login.error', error)});
         }


### PR DESCRIPTION
Added a new error message on the Login page and the login modal for the scenario that the ardana service cannot connect to keystone. This change depends on the ardana-service change https://gerrit.suse.provo.cloud/4843, which was merged into master on 10/03/2018. 

To test this in dev environment, you can shut down your keystone docker container with this command: docker stop <containerID>. Once you're done testing, you can bring back your keystone container with this command: docker start <containerID>.