### PR TITLE
Reduce scope of update mode

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -586,7 +586,7 @@ class InstallWizard extends Component {
   }
 
   renderProgressBar() {
-    return (<WizardProgress steps={this.state.steps} isUpdate={this.IS_UPDATE}/>);
+    return (<WizardProgress steps={this.state.steps}/>);
   }
 
   /**

--- a/src/components/WizardProgress.js
+++ b/src/components/WizardProgress.js
@@ -42,9 +42,9 @@ class WizardProgress extends Component {
         );
       }
     });
-    let cls = 'wizard-progress-container' + (this.props.isUpdate ? ' update' : '');
+
     return(
-      <div className={cls}>
+      <div className="wizard-progress-container">
         {stateBubbles}
       </div>
     );

--- a/src/styles/components/wizard.less
+++ b/src/styles/components/wizard.less
@@ -14,16 +14,19 @@
 **/
 @import "./../palette.less";
 
+// When contained within the navigation menu, restrict the width of the progress bar
+.content {
+  .wizard-progress-container {
+    width: 60%;
+  }
+}
+
 .wizard-progress-container {
   height: 2em;
   margin: 3.5em 0 2.5em;
   background-image: url(../../images/dot.png);
   display: flex;
   justify-content: space-between;
-
-  &.update {
-    width: 60%;
-  }
 
   > span:before {
     font-weight: bold;


### PR DESCRIPTION
The install wizard has an "update" mode that should be contained
as much as possible to the functioning of the wizard itself.  Removed
the code to pass along this mode flag to WizardProgress and used CSS
alone to do the styling.