### PR TITLE
SCRD-3497 Fix field validation in replace server dialog

### DIFF
--- a/src/components/CollapsibleTable.js
+++ b/src/components/CollapsibleTable.js
@@ -310,7 +310,16 @@ class CollapsibleTable extends Component {
   renderReplaceServerModal() {
     let title = translate('server.replace.heading', this.state.activeRowData.id);
     let newProps = { ...this.props };
-    newProps.knownServers = [].concat(this.props.manualServers || []).concat(this.props.autoServers || []);
+
+    const modelIds = this.props.model.getIn(['inputModel','servers'])
+      .map(server => server.get('uid') || server.get('id'));
+
+    // The servers that can be used for possible replacements are all of those discovered servers (either
+    //   manually or automatic) that are *not* already assigned somewhere in the model
+    const available = [].concat(this.props.manualServers || []).concat(this.props.autoServers || [])
+      .filter(server => ! modelIds.includes(server.uid));
+
+    newProps.availableServers = available;
 
     return (
       <BaseInputModal

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -423,6 +423,7 @@
     "network.groups": "Network Groups",
     "forced.network.groups": "Forced Network Groups",
 
+    "duplicate.error": "Already in use",
     "complete.heading": "Cloud Deployment Successful",
     "complete.message.body1": "Congratulations! You've successfully deployed your cloud.",
     "complete.message.body2": "This is the information about your cloud:",

--- a/src/utils/InputValidators.js
+++ b/src/utils/InputValidators.js
@@ -316,3 +316,54 @@ export function IpInNetmaskValidator(ip, netmask) {
   const netmaskInt = ipAddrToInt(netmask);
   return (ipInt & netmaskInt) >>> 0 === ipInt;
 }
+
+// Return a validator that requires the entered value to
+// NOT be in the given list or set.
+//
+// Note that the counterpart to this validator, createIncludesValidator,
+// is generally unnecessary, since a pulldown list would normally
+// be used in the situation where there is a fixed set of valid inputs.
+export function createExcludesValidator(values) {
+
+  function validator(value) {
+
+    let exists;
+    if (typeof(values) === 'object' && values instanceof Set) {
+      exists = values.has(value);
+    } else {
+      exists = values.includes(value);
+    }
+
+    if (exists) {
+      return {
+        isValid: false,
+        errorMsg: translate('duplicate.error', value)
+      };
+    } else {
+      return { isValid: true };
+    }
+  }
+
+  return validator;
+}
+
+// Return a single validator function that in turn invokes multiple validators, and
+// returning the result if any fail.
+// This permits checking against multiple criteria simply; without this, checking
+// against multiple criteria requires either creating a single function that has multiple
+// ways of using it (depending on which criteria are to be enforced), or it requires
+// a writing a combinatorial number of functions depending on the criteria
+export function chainValidators(...validators) {
+
+  function chained(value) {
+    for (let validator of validators) {
+      const result = validator(value);
+      if (! result.isValid) {
+        return result;
+      }
+    }
+    return { isValid: true };
+  }
+
+  return chained;
+}


### PR DESCRIPTION
The field validation in the replace server dialog had three problems:
- It did not exclude in-use servers from the pulldown list of
  available servers.
- The duplicate check should have flagged only those values used in
  a server in the model
- The duplicate IP address check should have checked against IP
  addresses used either as the main server address or its ILO address

In the process of improving the parameters to the validator I found
that the existing mechanism of checking for duplicates required very
tight coupling between the validator function and the field being
validated: specifically, the validator required that the input be
passed with two hardcoded properties, each of which needed to contain
a very specific structure.  Rather than propagating that further,
established a more general validation function for checking for
duplicates and for checking multiple criteria.