### PR TITLE
SCRD-3485 Add wait time to run status playbook

### DIFF
--- a/src/components/PlaybookProcess.js
+++ b/src/components/PlaybookProcess.js
@@ -18,6 +18,7 @@ import { translate } from '../localization/localize.js';
 import { getAppConfig } from '../utils/ConfigHelper.js';
 import { fetchJson, postJson, deleteJson } from '../utils/RestUtils.js';
 import { STATUS } from '../utils/constants.js';
+import { sleep } from '../utils/MiscUtils.js';
 import { ActionButton } from '../components/Buttons.js';
 import io from 'socket.io-client';
 import { List } from 'immutable';
@@ -270,23 +271,25 @@ class PlaybookProgress extends Component {
   }
 
   processEndMonitorPlaybook = (playbookName) => {
-    this.socket.disconnect();
-    const thisPlaybook = this.globalPlaybookStatus.find(e => e.name === playbookName);
-    // the global playbookStatus should be updated in playbookError or playbookStopped
-    if(thisPlaybook && thisPlaybook.status === STATUS.COMPLETE) {
-      let nextPlaybookName = this.findNextPlaybook(thisPlaybook.name);
-      if (nextPlaybookName) {
-        this.launchPlaybook(nextPlaybookName);
-      }
-      else {
-        this.props.updatePageStatus(STATUS.COMPLETE); //set the caller page status
-      }
-    } else {
-      // in case of running only one playbook that has no playbook-stop tag
-      if (thisPlaybook && this.globalPlaybookStatus.length === 1 && thisPlaybook.status === STATUS.IN_PROGRESS) {
-        this.setState((prevState) => {
-          return {'playbooksComplete': prevState.playbooksComplete.concat(playbookName + '.yml')};
-        });
+    if (this.socket.connected) {
+      this.socket.disconnect();
+      const thisPlaybook = this.globalPlaybookStatus.find(e => e.name === playbookName);
+      // the global playbookStatus should be updated in playbookError or playbookStopped
+      if(thisPlaybook && thisPlaybook.status === STATUS.COMPLETE) {
+        let nextPlaybookName = this.findNextPlaybook(thisPlaybook.name);
+        if (nextPlaybookName) {
+          this.launchPlaybook(nextPlaybookName);
+        }
+        else {
+          this.props.updatePageStatus(STATUS.COMPLETE); //set the caller page status
+        }
+      } else {
+        // in case of running only one playbook that has no playbook-stop tag
+        if (thisPlaybook && this.globalPlaybookStatus.length === 1 && thisPlaybook.status === STATUS.IN_PROGRESS) {
+          this.setState((prevState) => {
+            return {'playbooksComplete': prevState.playbooksComplete.concat(playbookName + '.yml')};
+          });
+        }
       }
     }
   }
@@ -670,7 +673,7 @@ class PlaybookProgress extends Component {
       // handle the case when can not receive end event for playbook
       let lastStepPlaybooks = this.props.steps[this.props.steps.length - 1].playbooks;
       if(lastStepPlaybooks.indexOf(playbookName + '.yml') !== -1) {
-        this.processEndMonitorPlaybook(playbookName);
+        sleep(2000).then(() => {this.processEndMonitorPlaybook(playbookName);});
       }
     }
   }

--- a/src/utils/MiscUtils.js
+++ b/src/utils/MiscUtils.js
@@ -1,0 +1,21 @@
+// (c) Copyright 2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+/**
+ * usage:  sleep(500).then(() => {console.log('do something after the sleep')});
+ */
+export function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}


### PR DESCRIPTION
This change is to fix the problem of running status playbook does not display the last few lines of the log due to the fact that the socket connection was severed right away. Added a 2-second wait time in the process to wait for the 'end tag' to arrive which should be plenty for the last few lines of the log to show up.