### PR TITLE
SCRD-4240 Add passphrase modal to run status playbook

### DIFF
--- a/src/components/CollapsibleTable.js
+++ b/src/components/CollapsibleTable.js
@@ -230,7 +230,7 @@ class CollapsibleTable extends Component {
   renderMenuAction = (server) => {
     return (
       <span className='menu-icon' onClick={(event) => this.handleShowMenu(event, server)}>
-        <i className='material-icons'>more_vert</i>
+        <i className='material-icons'>more_horiz</i>
       </span>
     );
   }

--- a/src/components/PlaybookProcess.js
+++ b/src/components/PlaybookProcess.js
@@ -285,7 +285,7 @@ class PlaybookProgress extends Component {
         }
       } else {
         // in case of running only one playbook that has no playbook-stop tag
-        if (thisPlaybook && this.globalPlaybookStatus.length === 1 && thisPlaybook.status === STATUS.IN_PROGRESS) {
+        if (thisPlaybook && this.globalPlaybookStatus.length === 1) {
           this.setState((prevState) => {
             return {'playbooksComplete': prevState.playbooksComplete.concat(playbookName + '.yml')};
           });

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -62,6 +62,10 @@
     "legend.warning": "Warning",
     "legend.unknown": "Unknown",
     "legend.ok": "ok",
+    "get.passphrase": "Provide SSH Passphrase",
+    "get.passphrase.description": "The operation you are about to perform requires the SSH passphrase. Please provide the SSH passphrase or select the Cancel button to abort the operation.",
+    "get.passphrase.invalid": "SSH passphrase provided is incorrect. Please provide the correct SSH passphrase.",
+    "get.passphrase.error": "Unable to use the provided SSH passphrase: {0}.\nPlease correct the problem and try again.",
 
     "day2.product.name": "CLM\nAdmin Console",
     "day2.product.description": "Manage and configure your OpenStack cloud via one interface, anytime, anywhere.",

--- a/src/styles/components/modals.less
+++ b/src/styles/components/modals.less
@@ -75,3 +75,14 @@
     }
   }
 }
+
+.passphrase-line {
+  display: flex;
+  margin: 2em 0 2em 4em;
+  .passphrase-heading {
+    width: 30%;
+  }
+  .passphrase-input {
+    width: 70%;
+  }
+}


### PR DESCRIPTION
Added "Provide SSH Passphrase" modal to the run status playbook step so that the user can provide their passphrase to be used to run the playbook. This hopefully will be a pattern that other run playbook steps can use when the passphrase is required. 

Oak and Dogwood in their current states do not have the ssh passphrase setup. The following steps set up the ssh process to require a passphrase:
1. back up the original id_rsa and id_rsa.pub files on the deployer
2. run 'ssh-keygen'  then provide a passphrase, this will create the new id_rsa and id_rsa.pub files
3. restart the ardana service
At this point the system will require a passphrase when you run any playbook (the 'requires_password' API will return 'true'). Once the passphrase is provided, it will be automatically used in all subsequent calls that require the passphrase. Therefore the passphrase is no longer needed, and the 'requires_password' API will return 'false'.

Also included fixes for a couple of issues:
1. switched to use the horizontal "more" icon instead of the vertical one in CollapsibleTable.js, per Gary's request
2. fixed PlaybookProcess.js's processEndMonitorPlaybook when running only one playbook which used to check for 'IN_PROCESS' status. Discovered during testing that if the status is 'FAILED', the playbook should've been marked completed as well but didn't. So the status check is removed. 

