### PR TITLE
SCRD-3489 Update Service Config - Part 3

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -446,6 +446,8 @@
     "deploy.progress.step5": "Quick health check",
     "deploy.progress.step6": "Additional Setup and Configuration",
     "deploy.progress.step7": "n/a",
+    "deploy.progress.update": "Update Configuration",
+    "deploy.progress.run.status": "Check Service Status",
     "deploy.commit.failure": "Failed to commit Cloud Installer changes. {0}",
     "deploy.fail.check.playbook": "Failed to check in-progress playbook status for {0} - {1}. {2}",
     "deploy.fail.launch.playbook": "Failed to launch playbook {0}. {1}",

--- a/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
+++ b/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
@@ -177,6 +177,12 @@ class ServiceTemplatesTab extends Component {
     this.props.hasChange(this.hasChange(updatedList));
   }
 
+  getChangedServices = () => {
+    const changedServices = this.state.serviceFiles.filter(srv => srv.changedFiles !== undefined)
+      .map(srv => srv.service);
+    return changedServices;
+  }
+
   removeOrigFiles = () => {
     this.state.serviceFiles.map((val) => {
       if (val.changedFiles) {


### PR DESCRIPTION
Added updating steps that are driven by the number of services being updated. If updating config files for one service, runs the service -reconfigure.yml and -status.yml. If updating config files for more than one service, only runs ardana-reconfigure.yml (which calls ardana-status.yml at the end).

Tested on Dogwood but I had to temporary change the PRE_DEPLOYMENT_PLAYBOOK in constants.js to 'dayzero-pre-deployment' because installui-pre-deployment did not exist yet.