### PR TITLE
SCRD-3497 Support running non-playbooks with PlaybookProgress

### DIFF
--- a/src/pages/ReplaceServer/PrepareReplace.js
+++ b/src/pages/ReplaceServer/PrepareReplace.js
@@ -138,7 +138,7 @@ class PrepareReplace extends BaseUpdateWizardPage {
           {this.renderHeading(translate('server.replace.prepare'))}
         </div>
         <div className='wizard-content'>
-          {!cancel && this.state.startPlayBook && this.renderPlaybookProgress()}
+          {this.state.startPlayBook && this.renderPlaybookProgress()}
           {cancel && this.renderError()}
         </div>
         {this.renderNavButtons(cancel)}

--- a/src/pages/ReplaceServer/PrepareReplace.js
+++ b/src/pages/ReplaceServer/PrepareReplace.js
@@ -19,10 +19,14 @@ import { PRE_DEPLOYMENT_PLAYBOOK, STATUS } from '../../utils/constants.js';
 import BaseUpdateWizardPage from '../BaseUpdateWizardPage.js';
 import { PlaybookProgress } from '../../components/PlaybookProcess.js';
 import { ErrorBanner } from '../../components/Messages.js';
-import {postJson} from '../../utils/RestUtils.js';
+import { fetchJson, postJson } from '../../utils/RestUtils.js';
 
 
 const PLAYBOOK_STEPS = [
+  {
+    label: 'Check version',
+    playbooks: ['version']
+  },
   {
     label: translate('deploy.progress.config-processor-run'),
     playbooks: ['config-processor-run.yml']
@@ -90,13 +94,29 @@ class PrepareReplace extends BaseUpdateWizardPage {
   }
 
   renderPlaybookProgress () {
+    const playbooks = [
+      {
+        // TODO: Replace this demo function with *real* functionality
+        name: 'version',
+        action: ((logger) => {
+          return fetchJson('/api/v1/clm/version')
+            .then((response) => {
+              logger('ardana-service version: '+response);
+            });
+        }),
+      },
+      {
+        name: PRE_DEPLOYMENT_PLAYBOOK,
+      }
+    ];
+
     return (
       <PlaybookProgress
         updatePageStatus={this.updatePageStatus}
         updateGlobalState={this.props.updateGlobalState}
         playbookStatus={this.props.playbookStatus}
         steps={PLAYBOOK_STEPS}
-        playbooks={[PRE_DEPLOYMENT_PLAYBOOK]}/>
+        playbooks={playbooks}/>
     );
   }
 


### PR DESCRIPTION
Add support for supplying an arbitrary action instead of only launching
ansible playbooks. The action is a function that returns a promise,
which enables it to be used for making API calls to the back end as well
as any other call.
Replaced logic that used isUpdateMode to indicate that the playbook
array was to contain objects (instead of just names) with logic that
inspected the array and made the decision based on the contents.
Added documentation for the props passed in to PlaybookProcess.
Added an example function in PrepareReplace.