### PR TITLE
SCRD-3497 Add PrepareController

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -437,6 +437,7 @@
 
     "deploy.progress.heading": "Cloud Deployment In Progress",
     "deploy.progress.config-processor-run": "Config Processor Run",
+    "deploy.progress.commit": "Model committed",
     "deploy.progress.ready-deployment": "Ready Deployment",
     "deploy.progress.predeployment": "Pre-Deployment",
     "deploy.progress.step1": "Network Configuration",
@@ -609,5 +610,10 @@
     "server.addserver.empty.computeroles.info": "There are no compute roles available",
     "server.addserver.installos.passphrase.error": "Passphrase Error",
     "server.addserver.compute.installos": "Installing SLES OS",
-    "server.addserver.compute.installos.complete": "Successfully Installed SLES OS on Compute Servers"
+    "server.addserver.compute.installos.complete": "Successfully Installed SLES OS on Compute Servers",
+    "update.known_hosts.failure": "Unable to remove server from known_hosts file. {0}",
+    "update.remove_cobbler.failure": "Unable to remove system from cobbler. {0}",
+    "server.deploy.progress.rm-known-host": "Remove server from known_hosts",
+    "server.deploy.progress.rm-cobbler": "Remove system from cobbler",
+    "server.deploy.progress.cobbler-deploy": "Deploying cobbler"
 }

--- a/src/pages/ReplaceServer/PrepareCompute.js
+++ b/src/pages/ReplaceServer/PrepareCompute.js
@@ -51,7 +51,7 @@ const PLAYBOOK_STEPS = [
 // page or remove it if it is not used eventually.
 // Please refer to pages/AddServers where it has the latest
 // framework process handling
-class PrepareReplace extends BaseUpdateWizardPage {
+class PrepareCompute extends BaseUpdateWizardPage {
 
   constructor(props) {
     super(props);
@@ -147,4 +147,4 @@ class PrepareReplace extends BaseUpdateWizardPage {
   }
 }
 
-export default PrepareReplace;
+export default PrepareCompute;

--- a/src/pages/ReplaceServer/PrepareController.js
+++ b/src/pages/ReplaceServer/PrepareController.js
@@ -1,0 +1,180 @@
+// (c) Copyright 2018 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+import React from 'react';
+import { translate } from '../../localization/localize.js';
+import { STATUS } from '../../utils/constants.js';
+import BaseUpdateWizardPage from '../BaseUpdateWizardPage.js';
+import { PlaybookProgress } from '../../components/PlaybookProcess.js';
+import { ErrorBanner } from '../../components/Messages.js';
+import { fetchJson, postJson, deleteJson } from '../../utils/RestUtils.js';
+
+class PrepareController extends BaseUpdateWizardPage {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      overallStatus: STATUS.UNKNOWN, // overall status of entire playbook and commit
+      invalidMsg: '',
+    };
+  }
+
+  setNextButtonDisabled = () => this.state.overallStatus != STATUS.COMPLETE;
+
+  updatePageStatus = (status) => {
+    this.setState({overallStatus: status});
+    if (status === STATUS.FAILED) {
+      this.setState({invalidMsg: translate('server.replace.prepare.failure')});
+    }
+  }
+
+  renderPlaybookProgress () {
+    const steps = [
+      {
+        label: translate('deploy.progress.commit'),
+        playbooks: ['commit']
+      },
+      {
+        label: translate('deploy.progress.config-processor-run'),
+        playbooks: ['config-processor-run.yml']
+      },
+      {
+        label: translate('deploy.progress.ready-deployment'),
+        playbooks: ['ready-deployment.yml']
+      },
+      {
+        label: translate('server.deploy.progress.rm-cobbler'),
+        playbooks: ['rm-cobbler']
+      },
+      {
+        label: translate('server.deploy.progress.rm-known-host'),
+        playbooks: ['known-hosts']
+      },
+      {
+        label: translate('server.deploy.progress.cobbler-deploy'),
+        playbooks: ['cobbler-deploy.yml']
+        // TODO:
+        //    cobbler-deploy *might* prompt for a password, although the logs on the QE system
+        //       ardana@10.84.81.17 indicate that none was supplied and it succesfully ran. Hmmmm
+      },
+    ];
+
+    const playbooks = [
+      {
+        name: 'commit',
+        action: ((logger) => {
+          const commitMessage = {'message': 'Committed via Ardana Installer'};
+          return postJson('/api/v1/clm/model/commit', commitMessage)
+            .then((response) => {
+              logger('Model committed\n');
+            })
+            .catch((error) => {
+              const message = translate('update.commit.failure', error.toString());
+              logger(message+'\n');
+              throw new Error(message);
+            });
+        }),
+      },
+      {
+        name: 'config-processor-run',
+      },
+      {
+        name: 'ready-deployment',
+      },
+      {
+        name: 'rm-cobbler',
+        action: ((logger) => {
+          return fetchJson('/api/v1/clm/cobbler/servers')
+            .then((response) => {
+              const cobbler_server = response.find((e) =>
+                e.ip === this.props.operationProps.server.ip ||
+                e.name === this.props.operationProps.server.name);
+              if (cobbler_server) {
+                const name = cobbler_server.name;
+
+                return deleteJson('/api/v1/clm/cobbler/servers/' + name)
+                  .then((response) => {
+                    logger('Host removed from cobbler\n');
+                  })
+                  .catch((error) => {
+                    const message = translate('update.remove_cobbler.failure', error.toString());
+                    logger(message+'\n');
+                    throw new Error(message);
+                  });
+
+              } else {
+                logger('Host not present in cobbler, continuing\n');
+              }
+            });
+        }),
+      },
+      {
+        name: 'known-hosts',
+        action: ((logger) => {
+          return deleteJson('/api/v1/clm/known_hosts/' + this.props.operationProps.server.id)
+            .then((response) => {
+              logger('Host removed from known_hosts\n');
+            })
+            .catch((error) => {
+              const message = translate('update.known_hosts.failure', error.toString());
+              logger(message+'\n');
+              throw new Error(message);
+            });
+        }),
+      },
+      {
+        name: 'cobbler-deploy',
+      },
+    ];
+
+    return (
+      <PlaybookProgress
+        updatePageStatus={this.updatePageStatus}
+        updateGlobalState={this.props.updateGlobalState}
+        playbookStatus={this.props.playbookStatus}
+        steps={steps}
+        playbooks={playbooks}/>
+    );
+  }
+
+  renderError () {
+    return (
+      <div className='banner-container'>
+        <ErrorBanner message={this.state.invalidMsg}
+          show={this.state.overallStatus === STATUS.FAILED}/>
+      </div>
+    );
+  }
+
+  render() {
+    //if error happens, cancel button shows up
+    let cancel =  this.state.overallStatus === STATUS.FAILED;
+    return (
+      <div className='wizard-page'>
+        <div className='content-header'>
+          {this.renderHeading(translate('server.replace.prepare'))}
+        </div>
+        <div className='wizard-content'>
+          {this.renderPlaybookProgress()}
+          {cancel && this.renderError()}
+        </div>
+        {this.renderNavButtons(cancel)}
+      </div>
+    );
+  }
+}
+
+export default PrepareController;

--- a/src/pages/ReplaceServer/UpdateServerPages.js
+++ b/src/pages/ReplaceServer/UpdateServerPages.js
@@ -13,14 +13,16 @@
 * limitations under the License.
 **/
 
-import PrepareReplace from './PrepareReplace.js';
+import PrepareCompute from './PrepareCompute.js';
+import PrepareController from './PrepareController.js';
 import InstallOS from './InstallOS.js';
 import UpdateComplete from './UpdateComplete.js';
 
 // potential pages for all kinds of server replacement pages
 export const UpdateServerPages = {
-  'PrepareReplace' :  PrepareReplace,
-  'InstallOS' : InstallOS,
+  'PrepareCompute': PrepareCompute,
+  'PrepareController': PrepareController,
+  'InstallOS': InstallOS,
   //TODO more possible pages list here
   'UpdateComplete': UpdateComplete
 };

--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -154,10 +154,17 @@ class UpdateServers extends BaseUpdateWizardPage {
   assembleProcessPages = (theProps) => {
     let pages = [];
 
-    pages.push({
-      name: 'PrepareReplace',
-      component: UpdateServerPages.PrepareReplace
-    });
+    if(isComputeNode(this.state.serverToReplace)) {
+      pages.push({
+        name: 'PrepareCompute',
+        component: UpdateServerPages.PrepareCompute
+      });
+    } else {
+      pages.push({
+        name: 'PrepareController',
+        component: UpdateServerPages.PrepareController
+      });
+    }
 
     //TODO other pages based on the theProps
 


### PR DESCRIPTION
Add a new page for the prepare server workflow that is specifically for
preparing control nodes for replacement, up to the point where the OS
installation would begin.  Moved the model commit into an action so that
it will not be repeated when the page is realoaded.
Moved PrepareReplace to PrepareCompute, since the workflow for replacing
a compute node is different.