### PR TITLE
 SCRD-3497 Use install os provision playbook

### DIFF
--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -159,26 +159,25 @@ class UpdateServers extends BaseUpdateWizardPage {
         name: 'PrepareCompute',
         component: UpdateServerPages.PrepareCompute
       });
+
+      if(theProps.installOS) {
+        pages.push({
+          name: 'InstallOS',
+          component: UpdateServerPages.InstallOS
+        });
+      }
+
+      pages.push({
+        name: 'UpdateComplete',
+        component: UpdateServerPages.UpdateComplete
+      });
+
     } else {
       pages.push({
         name: 'PrepareController',
         component: UpdateServerPages.PrepareController
       });
     }
-
-    //TODO other pages based on the theProps
-
-    if(theProps.installOS) {
-      pages.push({
-        name: 'InstallOS',
-        component: UpdateServerPages.InstallOS
-      });
-    }
-
-    pages.push({
-      name: 'UpdateComplete',
-      component: UpdateServerPages.UpdateComplete
-    });
     return pages;
   }
 


### PR DESCRIPTION
Replace call to cobbler deploy with a call to the
install-ui-os-provision playbook, which is also used by the install
wizard.
Support defaulting and passing extra-vars in both install and update
scenarios.