### PR TITLE
Rename replace controller page, refactor arrays

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -581,7 +581,7 @@
     "replace.server.poweroff.warning": "The controller node must be powered off before it can be replaced since the new node will re-use the same IP address.\nPower off this node and continue",
     "replace.server.nomigration.warning": "The compute host {0} with IP {1} is not reachable, the replacement process won't be able to migrate instances. \n\n Do you still want to procceed?",
     "server.replace.details.select.message": "Check and select from the available servers to fill out inputs.",
-    "server.replace.prepare": "Preparing Replace Server in Progress",
+    "server.replace": "Server Replacement in Progress",
     "server.replace.complete.heading": "Completed Server Replacement",
     "server.replace.complete": "Completed replacing server {0}",
     "server.replace.prepare.failure": "Failed to prepare for replacing server",

--- a/src/pages/ReplaceServer/UpdateServerPages.js
+++ b/src/pages/ReplaceServer/UpdateServerPages.js
@@ -14,14 +14,14 @@
 **/
 
 import PrepareCompute from './PrepareCompute.js';
-import PrepareController from './PrepareController.js';
+import ReplaceController from './ReplaceController.js';
 import InstallOS from './InstallOS.js';
 import UpdateComplete from './UpdateComplete.js';
 
 // potential pages for all kinds of server replacement pages
 export const UpdateServerPages = {
   'PrepareCompute': PrepareCompute,
-  'PrepareController': PrepareController,
+  'ReplaceController': ReplaceController,
   'InstallOS': InstallOS,
   //TODO more possible pages list here
   'UpdateComplete': UpdateComplete

--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -174,8 +174,8 @@ class UpdateServers extends BaseUpdateWizardPage {
 
     } else {
       pages.push({
-        name: 'PrepareController',
-        component: UpdateServerPages.PrepareController
+        name: 'ReplaceController',
+        component: UpdateServerPages.ReplaceController
       });
     }
     return pages;


### PR DESCRIPTION
Rename PrepareController to ReplaceController, since the single page
will handle all steps in a single page.  Combine the 'playbooks' and
'steps' arrays into a single array with the goal of being able to
share certain entries in this array across multiple workflows.