### PR TITLE
SCRD-3497 Reconfigure ceilometer

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -629,5 +629,6 @@
     "server.deploy.progress.os-config": "Performing OS configuration",
     "server.deploy.progress.swift-check": "Restore swift ring builder files",
     "server.deploy.progress.swift-manual": "The server being replaced is the swift ring builder.  In order to proceed, the swift ring build files need to be manually copied from one of the other swift nodes.  Please follow the instructions in the section 15.6.2.7 of the operations guide. When this has been completed, click on Done to continue with the server replacement.",
-    "server.deploy.progress.ardana-deploy": "Running ardana-deploy"
+    "server.deploy.progress.ardana-deploy": "Running ardana-deploy",
+    "server.deploy.progress.ceilometer": "Reconfigure ceilometer"
 }

--- a/src/pages/ReplaceServer/ReplaceController.js
+++ b/src/pages/ReplaceServer/ReplaceController.js
@@ -255,6 +255,9 @@ class ReplaceController extends BaseUpdateWizardPage {
       label: translate('server.deploy.progress.ardana-deploy'),
       playbook: 'ardana-deploy.yml',
       payload: {'extra-vars': {'rebuild': 'True'}, limit: deploy_limit}
+    },{
+      label: translate('server.deploy.progress.ceilometer'),
+      playbook: 'ceilometer-reconfigure.yml',
     });
 
     let playbooks = [];


### PR DESCRIPTION
When a controller node is replaced, ceilometer may need to be
reconfigured based on the configuration.  Per section 12.3.5.5 of the
operations guide, this is only necessary when the controller node is a
dedicated MML node, but since the playbooks are idempotent, there is no
real downside to running them everywhere.