### PR TITLE
SCRD-3497 Avoid passing list in extra vars

### DIFF
--- a/src/pages/ReplaceServer/ReplaceController.js
+++ b/src/pages/ReplaceServer/ReplaceController.js
@@ -192,7 +192,7 @@ class ReplaceController extends BaseUpdateWizardPage {
             event: INSTALL_PLAYBOOK + '.yml'
           }],
           playbook: INSTALL_PLAYBOOK,
-          payload: {'extra-vars': {'nodelist': [serverId], 'ardanauser_password': installPass}}
+          payload: {'extra-vars': {'nodelist': serverId, 'ardanauser_password': installPass}}
         },
       );
     }


### PR DESCRIPTION
When calling the install playbook, the extra-vars should contain a node
list.  The node list should always be a simple string, rather than a
python list.  Note that in the event that multiple nodes are to be
supplied (not relevant in this change), the string should be a
comma-separated list of nodes.