### PR TITLE
SCRD-3479 Add activate/deactivate to server management for compute hosts

### DIFF
--- a/src/components/CollapsibleTable.js
+++ b/src/components/CollapsibleTable.js
@@ -141,8 +141,6 @@ class CollapsibleTable extends Component {
       if (!isProduction()) {
         // TODO: Add these as they are implemented
         /*
-            key: 'common.activate', action: ...
-            key: 'common.deactivate', action: ...
             key: 'common.delete', action: ...
         */
         // show replace button when there is no process operation going on
@@ -152,6 +150,26 @@ class CollapsibleTable extends Component {
             action: this.props.replaceServer,
             callbackData: row
           });
+          if (this.props.serverStatuses
+              && this.props.serverStatuses[row.id]
+              && typeof this.props.serverStatuses[row.id].status
+                === 'boolean') {
+            if (this.props.serverStatuses[row.id].status) {
+              items.push({
+                key: 'common.deactivate',
+                action: this.props.deactivateComputeHost,
+                active: true,
+                callbackData: row.id
+              });
+            } else if (!this.props.serverStatuses[row.id].status) {
+              items.push({
+                key: 'common.activate',
+                action: this.props.activateComputeHost,
+                active: true,
+                callbackData: row.id
+              });
+            }
+          }
         }
       }
     } else {

--- a/src/components/ContextMenu.js
+++ b/src/components/ContextMenu.js
@@ -40,7 +40,7 @@ class ContextMenu extends Component {
   render() {
     const items = this.props.items.map((item => {
       return (
-        <div className='menu-item' key={item.key} onClick={() => {item.action(item.callbackData);}}>
+        <div className='menu-item' key={item.key} onClick={() => {item.action?.(item.callbackData);}}>
           {translate(item.key)}
         </div>
       );

--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -48,8 +48,10 @@ export function ConfirmModal(props) {
 export function YesNoModal(props) {
   const footer = (
     <div className="btn-row">
-      <ActionButton type='default' clickAction={props.noAction} displayLabel={translate('no')}/>
-      <ActionButton clickAction={props.yesAction} displayLabel={translate('yes')}/>
+      <ActionButton
+        type='default' clickAction={props.noAction} displayLabel={translate('no')} isDisabled={props.disableNo}/>
+      <ActionButton
+        clickAction={props.yesAction} displayLabel={translate('yes')} isDisabled={props.disableYes}/>
     </div>
   );
 

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -670,5 +670,13 @@
     "server.deploy.progress.migration_info": "The followings are the progress regarding live migration of instances from {0} to {1}. Once migration is all done, you can continue by clicking Done. However certain instances might not be able to migrated. \n Click Cancel to cancel the process, click Done to continue the process.",
     "server.deploy.progress.migration_pct": "{0}%",
     "server.deploy.progress.get_instances.error": "Failed to get instances {0}",
-    "server.deploy.progress.migration_monitor_done": "Monitoring instances migration is done"
+    "server.deploy.progress.migration_monitor_done": "Monitoring instances migration is done",
+
+    "server.activate.error": "Failed to activate server {0}",
+    "server.deactivate.error": "Failed to deactivate server {0}",
+    "server.deactivate.confirm.title": "Deactivate {0}?",
+    "server.deactivate.confirm.message": "Are you sure you want to deactivate this compute server, {0}?",
+    "server.deactivate.confirm.message_instances": "Are you sure you want to deactivate this compute server, {0} it is currently hosting {1} instances?",
+    "server.retreive.serverstatus.error": "Failed to retreive compute server status: {0}"
+
 }


### PR DESCRIPTION
There is still an issue with this. If the use is quick enough it is possible that the context menu will have no activate or deactivate option because the status is still loading from the backend.