### PR TITLE
SCRD-6126 Serve run_dist with ardana-service

### DIFF
--- a/run_dist.sh
+++ b/run_dist.sh
@@ -34,7 +34,7 @@ fi
 
 # Check out a local copy of the installer server
 if [ ! -d run ] ; then
-    git clone https://github.com/ArdanaCLM/ardana-installer-server run
+    git clone https://github.com/ArdanaCLM/ardana-service run
 fi
 
 cd run


### PR DESCRIPTION
When using run_dist.sh to create a locally running version of the
distributed UI, use the ardana service insted of the ardana installer
server.