### PR TITLE
SCRD-3480 - fix issue with false positive for monasca install

### DIFF
--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -135,7 +135,7 @@ class UpdateServers extends BaseUpdateWizardPage {
       this.setState({monasca: false});
       fetchJson('/api/v2/monasca/is_installed')
         .then(responseData => {
-          if(responseData.installed) {
+          if(responseData.installed === 'true') {
             this.setState({monasca: true}, () => this.getServerMonascaStatuses());
           }
         }).catch((error) => {


### PR DESCRIPTION
Since javascript interprets a String of "false" as `true` from a boolean perspective, the Monasca install check was always being interpreted as true, which causes unworkable queries in environments where no Monasca is actually installed