### PR TITLE
SCRD-3497 Fine tune replace controller per testing

### DIFF
--- a/src/components/CollapsibleTable.js
+++ b/src/components/CollapsibleTable.js
@@ -178,13 +178,11 @@ class CollapsibleTable extends Component {
       }
     } else {
       // not compute node
-      if(!isProduction()) {
-        items.push({
-          key: 'common.replace',
-          action: this.props.replaceServer,
-          callbackData: row
-        });
-      }
+      items.push({
+        key: 'common.replace',
+        action: this.props.replaceServer,
+        callbackData: row
+      });
     }
     return items;
   }

--- a/src/components/ReplaceServerDetails.js
+++ b/src/components/ReplaceServerDetails.js
@@ -37,7 +37,7 @@ class ReplaceServerDetails extends Component {
     super(props);
 
     this.state = {
-      isInstallOsSelected: false,
+      isInstallOsSelected: true,
       isWipeDiskSelected: false,
       isUseAvailServersSelected: false,
       inputValue: this.initInputs(props),
@@ -428,7 +428,8 @@ class ReplaceServerDetails extends Component {
   }
 
   renderServerContent() {
-    const modelServers = this.props.model.getIn(['inputModel','servers']);
+    const modelServers = this.props.model.getIn(['inputModel','servers'])
+      .filter(s => s.get('id') != this.props.data.id);
 
     const existingMacAddreses = modelServers.map(server => server.get('mac-addr'));
 

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -610,6 +610,8 @@
     "server.deploy.progress.gen-hosts-file": "Generate Host Files",
     "server.deploy.progress.addserver.deploy": "Deploy New Server(s)",
     "server.deploy.progress.update-monasca": "Update Monasca",
+    "server.deploy.progress.powerup": "Power up server",
+    "server.deploy.progress.waitssh": "Wait for server to become available",
     "server.deploy.addserver.complete": "Successfully Added Compute Servers",
     "server.deploy.addcompute.complete": "Successfully Added a Compute Server",
     "server.addserver.validate.error.title": "Failure of validating newly added servers",

--- a/src/pages/ReplaceServer/ReplaceController.js
+++ b/src/pages/ReplaceServer/ReplaceController.js
@@ -169,9 +169,10 @@ class ReplaceController extends BaseUpdateWizardPage {
       },
     ];
 
+    const serverId = this.props.operationProps.server.id;
+
     if(this.props.operationProps.installOS) {
       const installPass = this.props.operationProps.osInstallPassword || '';
-      const serverId = this.props.operationProps.server.id;
       // The following steps will all be performed via the INSTALL_PLAYBOOK
       playbook_steps.push(
         {
@@ -195,6 +196,21 @@ class ReplaceController extends BaseUpdateWizardPage {
           payload: {'extra-vars': {'nodelist': serverId, 'ardanauser_password': installPass}}
         },
       );
+    } else {
+      /*
+      playbook_steps.push(
+        {
+          label: translate('server.deploy.progress.powerup'),
+          playbook: 'bm-power-up.yml',
+          payload: {'extra-vars': {'nodelist': serverId}}
+        },
+        {
+          label: translate('server.deploy.progress.waitssh'),
+          playbook: 'bm-wait-for-ssh.yml',
+          payload: {'extra-vars': {'nodelist': serverId}}
+        }
+      );
+      */
     }
 
     playbook_steps.push(


### PR DESCRIPTION
In the process of testing the replace controller flow on a real system,
discovered and remedied several small changes that are needed:
- Enable the replace server function in production mode.  Since this
  code had not been tested fully, it was disabled in a production build.
- Permit the same IPMI IP address and mac address as the server being
  replaced.  This is particularly necessary when the processs has
  failed for some reason and you need to re-run it.
- When an OS installation is not chosen, then call playbooks to power up
  the node and wait for it to become available.  This is necessary
  because the node is required to be unavailable at the start of the
  process, and without this, the first playbook run against the new
  node will fail because it is unreachable via ssh.
- Change the default value of the checkbox for installing the OS to
  true, since that is the most likely thing for the user to do.