### PR TITLE
SCRD-5901 Add fallback font for when 'Arial' is not available

### DIFF
--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -217,7 +217,7 @@ p {
   height: 100vh;
   display: block;
   flex-direction: column;
-  font-family: Arial;
+  font-family: Arial, sans-serif;
   .top-bar-container {
     background-color: #00243E;
     .top-bar {


### PR DESCRIPTION
When the font Arial is not available some browsers will fall back to a serif/TimesNewRoman looking font which does not look similar to Arial at all.