### PR TITLE
SCRD-3111 Use smarter caching of internal model

### DIFF
--- a/src/pages/AddServers/DeployAddServers.js
+++ b/src/pages/AddServers/DeployAddServers.js
@@ -23,7 +23,7 @@ import {
   STATUS, WIPE_DISKS_PLAYBOOK, ARDANA_GEN_HOSTS_FILE_PLAYBOOK,
   SITE_PLAYBOOK, MONASCA_DEPLOY_PLAYBOOK, ARDANA_START_PLAYBOOK
 } from '../../utils/constants.js';
-import { fetchJson } from '../../utils/RestUtils.js';
+import { getInternalModel } from '../topology/TopologyUtils.js';
 
 const PLAYBOOK_POSSIBLE_STEPS = [{
   name: WIPE_DISKS_PLAYBOOK,
@@ -85,10 +85,7 @@ class DeployAddServers extends BaseUpdateWizardPage {
     // will request with no-cache
     if(!this.props.operationProps.newHosts) {
       this.setState({loading: true});
-      // fetchJson with url, init=undefined, forceLogin=true, noCache=true
-      fetchJson(
-        '/api/v2/model/cp_internal/CloudModel.yaml', undefined, true, true
-      )
+      getInternalModel()
         .then((cloudModel) => {
           let newHosts = this.getAddedComputeHosts(cloudModel);
           let cleanedHosts = newHosts.filter(host => host['hostname'] !== undefined);

--- a/src/pages/ReplaceServer/DisableComputeServiceNetwork.js
+++ b/src/pages/ReplaceServer/DisableComputeServiceNetwork.js
@@ -22,11 +22,12 @@ import { LoadingMask } from '../../components/LoadingMask.js';
 import { getHostFromCloudModel } from '../../utils/ModelUtils.js';
 import { PlaybookProgress } from '../../components/PlaybookProgress.js';
 import { ErrorBanner } from '../../components/Messages.js';
-import { putJson, deleteJson, fetchJson } from '../../utils/RestUtils.js';
+import { putJson, deleteJson } from '../../utils/RestUtils.js';
 import { ActionButton } from '../../components/Buttons.js';
 import { ConfirmModal } from '../../components/Modals.js';
 import InstanceMigrationMonitor from './InstanceMigrationMonitor.js';
 import { logProgressResponse, logProgressError } from '../../utils/MiscUtils.js';
+import { getInternalModel } from '../topology/TopologyUtils.js';
 
 const DISABLE_COMPUTE_SERVICE = 'disable_compute_service';
 const REMOVE_FROM_AGGREGATES = 'remove_from_aggregates';
@@ -58,10 +59,7 @@ class DisableComputeServiceNetwork extends BaseUpdateWizardPage {
   componentDidMount() {
     if (!this.props.operationProps.oldServer.hostname) {
       this.setState({loading: true});
-      // fetchJson with url, init=undefined, forceLogin=true, noCache=true
-      fetchJson(
-        '/api/v2/model/cp_internal/CloudModel.yaml', undefined, true, true
-      )
+      getInternalModel()
         .then((cloudModel) => {
           this.setState({loading: false});
           let oldHost =

--- a/src/pages/topology/TopologyUtils.js
+++ b/src/pages/topology/TopologyUtils.js
@@ -14,22 +14,12 @@
 **/
 import { fetchJson } from '../../utils/RestUtils.js';
 
-// Intead of doing this base-class thing, just use something like ConfigHelper.js used
-// to do for the config promise, which is to always return a promise, which may or may
-// not have been resolved already
-//
-var modelPromise;
-
-function loadInternalModel() {
-  return fetchJson('/api/v2/model/cp_internal/CloudModel.yaml');
-}
-
 // Prevent wrapping on hyphens by replacing normal hyphen characters with the non-wrapping-hyphen character
 export function noHyphenWrap(s) {
   return s.replace(/-/g, '\u2011');
 }
 
 export function getInternalModel() {
-  modelPromise = modelPromise || loadInternalModel();
-  return modelPromise;
+  // fetch using the no-cache option to ensure we have the latest version of the model
+  return fetchJson('/api/v2/model/cp_internal/CloudModel.yaml', undefined, true, true);
 }


### PR DESCRIPTION
Loading the model that is output from the config processor, a.k.a., the
internal model, was potentially quite slow (up to about 10 seconds), so
the getInternalModel function was originally created in order to avoid
even re-querying the back-end, making the UI much faster.  But that
solution incorrectly served up old results after the config processor
was run again.  So some pages were bypassing getInternalModel and
performing the fetch directly and explicitly adding 'cache-control:
no-cache' in order to forcably re-load fresh results, and other pages
were not.

Re-factor the code to always use the no-cache header when reading the
internal model.  Note that the no-cache option has a misleading name,
since it actually compares the cached response with the ETag from the
server and only re-loads if necessary.