### PR TITLE
SCRD-6374 add option to force localize to use one language bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "react-bootstrap": "v1.0.0-beta.3",
     "react-collapsible": "^2.0.0",
     "react-dom": "^16.4.1",
-    "react-localization": "^0.1.1",
     "react-router-dom": "^4.1.1",
     "react-router-hash-link": "^1.2.0",
     "showdown": "^1.8.6",


### PR DESCRIPTION
* Copies the changes to localization to from #239.
* Adds a new function to force translate a particular key to a particular language.

This can be used as follows:
```js
import { en, translateForceLang } from '../localization/localize.js';
translateForceLang('some.key', en);
translateForceLang('some.key', 'en');
translateForceLang('some.key.with.stuff', en, 'one', 'two');
```