### PR TITLE
SCRD-3497 Avoid race condition with model save and commit

### DIFF
--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -125,7 +125,8 @@ class CloudModelPicker extends BaseWizardPage {
       this.setState({loading: true});
       // Load the full template, update the global model, and save it
       fetchJson('/api/v2/templates/' + this.state.selectedModelName)
-        .then(model => this.props.updateGlobalState('model', fromJS(model), this.props.next))
+        .then(model => this.props.updateGlobalState('model', fromJS(model)))
+        .then(() => this.props.next())
         .catch(error => {
           this.setState({
             errorContent: {

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -113,7 +113,8 @@ class CloudModelSummary extends BaseWizardPage {
 
     // Update the control plane in the global model, save it, and move to the next page
     let model = this.props.model.updateIn(this.PATH_TO_CONTROL_PLANE, val => this.state.controlPlane);
-    this.props.updateGlobalState('model', model, this.props.next);
+    this.props.updateGlobalState('model', model)
+      .then(() => this.props.next());
   }
 
   renderItems = (section) => {

--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -324,7 +324,7 @@ class UpdateServers extends BaseUpdateWizardPage {
   // theProps includes zero or more of the items like
   // wipeDisk, installOS, osUsername, osPassword,
   // selectedServerId
-  replaceServer = (server, theProps) =>  {
+  replaceServer = async (server, theProps) =>  {
     let model;
 
     let repServer = Object.assign({}, server);
@@ -356,7 +356,9 @@ class UpdateServers extends BaseUpdateWizardPage {
 
     this.updateServerForReplaceServer(repServer);
 
-    this.props.updateGlobalState('model', model);
+    // Update the global state. Since this saves the model and updates the state, wait for
+    // it to complete before moving on.
+    await this.props.updateGlobalState('model', model);
 
     // existing server id and ip-addr for non-compute node
     // new server id and ip-addr for a new compute node
@@ -638,8 +640,8 @@ class UpdateServers extends BaseUpdateWizardPage {
     this.setState({showReplaceModal: false, serverToReplace: undefined});
   }
 
-  handleDoneReplaceServer = (server, theProps) => {
-    this.replaceServer(server, theProps);
+  handleDoneReplaceServer = async (server, theProps) => {
+    await this.replaceServer(server, theProps);
     this.handleCancelReplaceServer();
   }
 


### PR DESCRIPTION
The step to commit the model did not first wait for the model to be
saved, and if the commit happened first, then uncommitted changes would
result, causing the replace controller flow to terminate.  Modify the
updateGlobalState function to return a promise that is resolved when
the save is complete, so that the following functions can be
synchronized properly.