### PR TITLE
SCRD-6373 Re-join websocket after network interruptions

### DIFF
--- a/src/components/PlaybookProgress.js
+++ b/src/components/PlaybookProgress.js
@@ -275,21 +275,20 @@ class PlaybookProgress extends Component {
   }
 
   monitorSocket = (playbookName, playId) => {
+
     // Note that this function is only called after a fetch has completed, and thus
     // the application config has already completed loading, so getAppConfig can
     // be safely used here
     this.socket = io(getAppConfig('shimurl'));
     this.socket.on('playbook-start', this.playbookStarted);
-    this.socket.on(
-      'playbook-stop',
-      (stepPlaybook) => { this.playbookStopped(stepPlaybook, playbookName, playId); });
-    this.socket.on(
-      'playbook-error',
-      (stepPlaybook) => { this.playbookError(stepPlaybook, playbookName, playId); });
+    this.socket.on('playbook-stop', (stepPlaybook) => {
+      this.playbookStopped(stepPlaybook, playbookName, playId);
+    });
+    this.socket.on('playbook-error', (stepPlaybook) => {
+      this.playbookError(stepPlaybook, playbookName, playId);
+    });
     this.socket.on('log', this.logMessage);
-    this.socket.on(
-      'end',
-      () => { this.processEndMonitorPlaybook(playbookName); });
+    this.socket.on('end', this.processEndMonitorPlaybook);
     this.socket.emit('join', playId);
   }
 

--- a/src/components/PlaybookProgress.js
+++ b/src/components/PlaybookProgress.js
@@ -289,7 +289,12 @@ class PlaybookProgress extends Component {
     });
     this.socket.on('log', this.logMessage);
     this.socket.on('end', this.processEndMonitorPlaybook);
-    this.socket.emit('join', playId);
+    this.socket.on('connect', () => { this.socket.emit('join', playId); });
+    this.socket.on('disconnect', (reason) => {
+      if (reason === 'transport close') {
+        console.log('Connection lost, trying to reconnect...'); // eslint-disable-line no-console
+      }
+    });
   }
 
   // "Playbooks" come in a couple varieties. Originally they were just names, but


### PR DESCRIPTION
By default the socket IO client library will detect interruptions in
communications with the server and automatically retry continually.
But when connectivity is re-established, the client is not automitically
re-added to room in which it was listening for messages.  This change
moves the code to join the room into the callback function that is
triggered whenever the connection (or re-connection) succeeds.