### PR TITLE
SCRD-3481 - add filesystem utilization metrics from Monasca 

### DIFF
--- a/src/components/ModelServerDetails.js
+++ b/src/components/ModelServerDetails.js
@@ -15,6 +15,7 @@
 import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
 import { maskPassword } from '../utils/ModelUtils.js';
+import { ProgressBar } from 'react-bootstrap';
 
 class ModelServerDetails extends Component {
   renderTextLine(title, value) {
@@ -61,12 +62,30 @@ class ModelServerDetails extends Component {
     );
   }
 
+  renderDiskUtilization(mountpoint) {
+    //reactJs complains if the bsStyle or bsClass attributes are used in the ProgressBar,
+    //so instead the css styling is done via the inner classes of progress and progress-bar
+    return(
+      <tr key={mountpoint.name}>
+        <td>{mountpoint.name}</td>
+        <td>
+          <ProgressBar now={mountpoint.usedpct} label={mountpoint.usedpct + '%'} />
+        </td>
+      </tr>
+    );
+  }
+
   renderDetailsContent = () => {
     if(this.props.data) {
       let network_info;
+      let disk_info;
       if(this.props.data.networks) {
         network_info = this.props.data.networks.map(network => this.renderNetworkBlurb(network));
       }
+      if(this.props.data.diskUtilization) {
+        disk_info = this.props.data.diskUtilization.map(mountpoint => this.renderDiskUtilization(mountpoint));
+      }
+
       return (
         <div className='server-details-container'>
           {this.renderTextLine('server.id.prompt', this.props.data.id)}
@@ -78,10 +97,17 @@ class ModelServerDetails extends Component {
           {this.renderTextLine('server.ipmi.ip.prompt', this.props.data['ilo-ip'])}
           {this.renderTextLine('server.ipmi.username.prompt', this.props.data['ilo-user'])}
           {this.renderTextLine('server.ipmi.password.prompt', maskPassword(this.props.data['ilo-password']))}
-          {network_info ? translate('network.interfaces') : ''}
+          {network_info?.length > 0 ? translate('network.interfaces') : ''}
           <div className='inetFaces'>
             {network_info}
           </div>
+          {disk_info?.length > 0 ? translate('disk.filesystems.util') : ''}
+          <table className='fsutils'>
+            <thead></thead>
+            <tbody>
+              {disk_info}
+            </tbody>
+          </table>
         </div>
       );
     }

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -422,6 +422,7 @@
     "interface.model": "Interface Model",
     "interface.name": "Network Interface Name",
     "network.interfaces": "Network Interfaces",
+    "disk.filesystems.util": "Filesystem Utilization",
     "bond.device.name": "Bond Device Name",
     "bond.options": "Bond Options",
     "details.interfacemodel.confirm.remove": "You've selected to remove the interface model: {0}.\n\n Are you sure you want to proceed?",

--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -34,6 +34,7 @@ import { BaseInputModal, ConfirmModal, YesNoModal } from '../components/Modals.j
 import { genUID } from '../utils/ModelUtils.js';
 import { getInternalModel } from './topology/TopologyUtils';
 import { fromJS } from 'immutable';
+import { isMonascaInstalled } from '../utils/MonascaUtils.js';
 
 class UpdateServers extends BaseUpdateWizardPage {
 
@@ -127,7 +128,7 @@ class UpdateServers extends BaseUpdateWizardPage {
    * checks to see if Monasca is installed, and if it is, triggers a call to the status
    * of each server in the model
    */
-  checkMonasca() {
+  async checkMonasca() {
     if(this.state.monasca === undefined) {
       //default state.monasca to false, primarily to short circuit additional checks
       //this is because componentDidMount and componentDidUpdate both call into this
@@ -136,14 +137,10 @@ class UpdateServers extends BaseUpdateWizardPage {
       //usually being called twice, setting the state to false (from its original value of
       //undefined) prevents the 2nd call from duplicating the check and model load
       this.setState({monasca: false});
-      fetchJson('/api/v2/monasca/is_installed')
-        .then(responseData => {
-          if(responseData.installed) {
-            this.setState({monasca: true}, () => this.getServerMonascaStatuses());
-          }
-        }).catch((error) => {
-          console.log('error checking if Monasca is installed:' + error);// eslint-disable-line no-console
-        });
+      let isInstalled = await isMonascaInstalled();
+      if(isInstalled) {
+        this.setState({monasca: true}, () => this.getServerMonascaStatuses());
+      }
     } else if(this.state.monasca === true) {
       //if monasca is installed, get the server statuses
       this.getServerMonascaStatuses();

--- a/src/styles/components/serverutils.less
+++ b/src/styles/components/serverutils.less
@@ -152,6 +152,22 @@
       }
     }
   }
+
+  .fsutils{
+    width: 100%;
+    td:last-child {
+      width: 100%;
+      padding-left: 10px;
+    }
+    .progress{
+      margin: 3px 0px;
+      .progress-bar {
+        color: #000;//make the text in the progress bars black, the default white is hard to read when meter is low
+        background-color: @defaultshadow;
+        padding-left: 5px; //prevents the text from smooshing against the left side when meter is low
+      }
+    }
+  }
 }
 
 .message-line {

--- a/src/utils/MonascaUtils.js
+++ b/src/utils/MonascaUtils.js
@@ -1,0 +1,72 @@
+// (c) Copyright 2018 SUSE LLC
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+import { fetchJson } from '../utils/RestUtils.js';
+
+/**
+ * checks to see if Monasca is installed
+ */
+export async function isMonascaInstalled() {
+  try {
+    let installCheck = await fetchJson('/api/v2/monasca/is_installed');
+    if (installCheck ?.installed) {
+      return true;
+    }
+  } catch (error) {
+    console.log('error checking if Monasca is installed:' + error);// eslint-disable-line no-console
+  }
+
+  return false;
+}
+
+
+
+/**
+ * query monasca for disk utilization details
+ * @param {String} servername - the name of the server to query monasca with
+ */
+export async function loadServerDiskUtilization (servername) {
+  //const query = 'metric_dimensions=service:' + lookupName + '&group_by=state,severity';
+  let now_utc = (new Date()).getTime();
+  //go back to 1 minute so we can have data
+  let backtime_utc = now_utc - Number(60 * 1000);
+  let start_time = new Date(backtime_utc).toISOString();
+  let mountPoints = [];
+  let query = 'name=disk.space_used_perc&dimensions=hostname:' + servername +
+      '&group_by=*&start_time=' + start_time;
+
+  try {
+    let has_monasca = await isMonascaInstalled();
+    if(has_monasca) {
+      let used_perc_Data = await fetchJson('/api/v2/monasca/passthru/metrics/measurements?' + query);
+      //TODO - consider using a query for disk.total_space_mb and matching it up
+      // with the volume group specifications to know the actual free space and used
+      // rather than just a percentage
+      // the disk.total_space_mb measurement is for the whole disk, not per mount point
+      for (let entry in used_perc_Data.elements) {
+        let entry_val = used_perc_Data.elements[entry];
+        if (entry_val.measurements.length > 0) {
+          mountPoints.push({
+            'name': entry_val.dimensions.mount_point,
+            'usedpct': entry_val.measurements[0][1]//0 is the first datapoint, 1 is value (0 again would be timestamp)
+          });
+        }
+      }
+    }
+  } catch(error) {
+    console.log('failed to load disk metrics for server:' + servername);// eslint-disable-line no-console
+  }
+
+  return mountPoints;
+}


### PR DESCRIPTION
When Monasca is available on the system, load filesystem metrics for a server when a user views the server details.

The filesystem metrics are at the bottom of the details modal below the networks list