### PR TITLE
SCRD-3481 - only show Monasca column when Monasca is installed

### DIFF
--- a/src/components/CollapsibleTable.js
+++ b/src/components/CollapsibleTable.js
@@ -279,7 +279,17 @@ class CollapsibleTable extends Component {
     let icon = group.isExpanded ? 'expand_more' : 'expand_less';
 
     let fillerTds = [];
-    for (let i=0; i<Object.keys(group.members[0]).length - 7; i++) {
+    let numberOfVisbileColumns = 0;
+    for (let column of this.props.tableConfig.columns) {
+      if (!column.hidden) {
+        numberOfVisbileColumns++;
+      }
+    }
+
+    //the number of columns in the header
+    const headerColumnCount = 2;
+    //fill in extra td entries to match the columns from the rest of the table
+    for (let i=0; i< (numberOfVisbileColumns - headerColumnCount); i++) {
       fillerTds.push(<td key={i}></td>);
     }
 

--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -721,7 +721,7 @@ class UpdateServers extends BaseUpdateWizardPage {
         {name: 'server-group'},
         {name: 'nic-mapping'},
         {name: 'mac-addr'},
-        {name: 'monascaStatus', foundInProp: 'serverMonascaStatuses'},
+        {name: 'monascaStatus', foundInProp: 'serverMonascaStatuses', hidden: !this.state.monasca},
         {name: 'ilo-ip', hidden: true},
         {name: 'ilo-user', hidden: true},
         {name: 'ilo-password', hidden: true},

--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -208,22 +208,32 @@ class UpdateServers extends BaseUpdateWizardPage {
       .filter(s => s.role.includes('COMPUTE'))
       .map(s => {
         const internalServer = internalModelServers.filter(sev => sev.id === s.id)[0];
-        return {
-          ...s,
-          internal: internalServer,
-          hostname: internalServer.hostname
-        };
+        if(internalServer !== undefined) {
+          return {
+            ...s,
+            internal: internalServer,
+            hostname: internalServer.hostname
+          };
+        } else {
+          console.log('possible model inconsistency, internal model missing server id:' + s.id);
+        }
       });
 
-    let serversStatus = servers.map(s => fetchJson(`/api/v2/compute/services/${s.hostname}`));
+    let serversStatus = servers.map(s => {
+      if(s) {
+        return fetchJson(`/api/v2/compute/services/${s.hostname}`);
+      }
+    });
     const values = await Promise.all(serversStatus);
     let serverStatuses = {};
     for(const [index, status] of values.entries()) {
       const server = servers[index];
-      serverStatuses[server.id] = {
-        ...server,
-        status: status['nova-compute']
-      };
+      if(server) {
+        serverStatuses[server.id] = {
+          ...server,
+          status: status['nova-compute']
+        };
+      }
     }
     this.setState({serverStatuses});
   }


### PR DESCRIPTION
The collapsible table had a magic number that was incorrect calculating the number of columns to display. Fixed that issue and leveraged the fix to hide the Monsaca column when Monasca is not installed