### PR TITLE
SCRD-6669 Adjust layout when running playbooks

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -364,12 +364,13 @@ class InstallWizard extends Component {
   render() {
     // overwrite default tab title to use branding title
     document.title = translate('openstack.cloud.deployer.title');
+    const progressBar = this.renderProgressBar();
 
     return (
-      <div>
+      <div className={progressBar ? 'has-progress-bar' : ''}>
         <div className='wizard-header'>
           {this.renderTitle()}
-          {this.renderProgressBar()}
+          {progressBar}
         </div>
         <div className='wizard-content-container'>
           {this.renderLoadingMask()}

--- a/src/pages/AddServers.js
+++ b/src/pages/AddServers.js
@@ -357,7 +357,7 @@ class AddServers extends BaseUpdateWizardPage {
             {this.renderHeading(translate('add.server.add'))}
           </div>
         </div>
-        <div className='wizard-content unlimited-height'>
+        <div className='wizard-content'>
           {this.isValidToRenderServerContent() && this.renderAddPage()}
         </div>
         {this.renderDeployConfirmModal()}

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -1625,8 +1625,7 @@ class AssignServerRoles extends BaseWizardPage {
 
   render() {
     let serverId = this.state.activeRowData?.id || '';
-    const contentClass =
-      'wizard-content' + (this.props.isUpdateMode ? ' smaller-margin' : '');
+    const contentClass = this.props.isUpdateMode ? 'smaller-margin' : 'wizard-content';
     return (
       <div className='wizard-page'>
         {!this.props.isUpdateMode && this.renderCloudSettings()}

--- a/src/pages/ReplaceServer/ReplaceController.js
+++ b/src/pages/ReplaceServer/ReplaceController.js
@@ -336,7 +336,7 @@ class ReplaceController extends BaseUpdateWizardPage {
 
   renderError () {
     return (
-      <div className='banner-container'>
+      <div className='banner-container no-margin'>
         <ErrorBanner message={this.state.invalidMsg}
           show={this.state.overallStatus === STATUS.FAILED}/>
       </div>

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -372,3 +372,17 @@ a {
 .form-control{
   line-height: 20px;//in bootstrap 3 the default is 20px, in bootstrap 4 its 24px
 }
+
+/*
+The following variables are used to calculate how much space to reserve for headers and footers
+when displaying content page in several contexts:
+  day 0 : install wizard with progress bar
+  day 2 : with navigation menu
+  day 2 w/progress : navigation menu present AND a progress bar present.  This
+          is used in day 2 screens that have a multiple step workflow
+*/
+@day0-reserved-height: 0px; // unused and overriden whenever @content-height is referenced
+@day2-reserved-height: @day0-reserved-height - 106px;
+@day2-with-progress-reserved-height: @day2-reserved-height + 104px;
+@reserved-height: @day0-reserved-height;
+@content-height: calc(100vh - @reserved-height);

--- a/src/styles/components/logviewer.less
+++ b/src/styles/components/logviewer.less
@@ -12,15 +12,25 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 **/
-
 .log-viewer {
+  @day0-reserved-height: 367px;
+
   position: relative;
   min-width: 45em;
-  min-height: 45em;
+
   pre {
-    min-height: 45em;
-    max-height: 45em;
-    overflow: auto;
+    height: @content-height;
+
+    // When contained within a main-window (i.e. day 2), adjust
+    // the reserved height due to the thinner menu bar
+    .main-window .has-progress-bar & {
+      @reserved-height: @day2-with-progress-reserved-height;
+      height: @content-height;
+    }
+    .main-window & {
+      @reserved-height: @day2-reserved-height;
+      height: @content-height;
+    }
     font-size: 13px;
     //below here are bootstrap4 overrides that were not needed with bs3
     background-color: #f5f5f5;

--- a/src/styles/components/playbookprogress.less
+++ b/src/styles/components/playbookprogress.less
@@ -52,7 +52,6 @@
   .progress-body {
     display: inline-block;
     width: 100%;
-    // min-height: 40em;
   }
   .log {
     position: relative;

--- a/src/styles/components/playbookprogress.less
+++ b/src/styles/components/playbookprogress.less
@@ -13,11 +13,23 @@
 * limitations under the License.
 **/
 .playbook-progress {
+  @day0-reserved-height: 367px;
+
   ul {
+    height: @content-height;
+
+    // When contained within a main-window (i.e. day 2), adjust
+    // the reserved height due to the thinner menu bar
+    .main-window .has-progress-bar & {
+      @reserved-height: @day2-with-progress-reserved-height;
+      height: @content-height;
+    }
+    .main-window & {
+      @reserved-height: @day2-reserved-height;
+      height: @content-height;
+    }
     list-style-type: none;
     line-height: 2.5em;
-    min-height: 25em;
-    height: 30em;
     overflow: auto;
     color: gray;
     font-size: 1.2em;
@@ -40,14 +52,18 @@
   .progress-body {
     display: inline-block;
     width: 100%;
-    min-height: 40em;
+    // min-height: 40em;
   }
   .log {
+    position: relative;
     margin-top: 1em;
-    min-height: 30em;
-    height: 30em;
-    overflow: auto;
-    background-color: white;
+    min-height: 1em;
+    font-size: 13px;
+    background-color: #f5f5f5;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 9.5px;
+    height: calc(100vh - 387px);
   }
   .error-heading {
     font-size: 1.1em;

--- a/src/styles/components/serverprovision.less
+++ b/src/styles/components/serverprovision.less
@@ -48,4 +48,11 @@
       margin-bottom: 0;
     }
   }
+
+  &.no-margin {
+    margin: 0;
+    .alert {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/src/styles/components/wizard.less
+++ b/src/styles/components/wizard.less
@@ -148,6 +148,16 @@
 }
 
 .wizard-content-container .wizard-content {
+  // 291px is calculated as:
+  //   20px for top margin for h1 header (controlled by bootstrap)
+  //   28px for h1 header
+  //   104px for wizard-progress-container
+  //   44px for content-header and top margin
+  //   20px for wizard-content top and bottom margins
+  //   55px for footer-container
+
+  @day0-reserved-height: 291px;
+
   margin: 20px;
   &.smaller-margin {
     margin: 3px;
@@ -157,14 +167,18 @@
     margin-bottom: 10px;
   }
 
-  // 291px is calculated as:
-  //   20px for top margin for h1 header (controlled by bootstrap)
-  //   28px for h1 header
-  //   104px for wizard-progress-container
-  //   44px for content-header and top margin
-  //   40px for wizard-content top and bottom margins
-  //   55px for footer-container
-  height: calc(~"100vh - 291px");
+  height: @content-height;
+
+  // When contained within a main-window (i.e. day 2), adjust
+  // the reserved height due to the thinner menu bar
+  .main-window .has-progress-bar & {
+      @reserved-height: @day2-with-progress-reserved-height;
+      height: @content-height;
+  }
+  .main-window & {
+    @reserved-height: @day2-reserved-height;
+    height: @content-height;
+  }
 
   &.unlimited-height {
     height: auto;


### PR DESCRIPTION
Adjust layout of screens when running playbooks.  Both day 0 and day 2
re-use some of the same components, but since they have different sized
headers at the top of the screen, some of the calculations have to
adjust for these differences.