### PR TITLE
Update precommit hook to handle renames

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -2,7 +2,7 @@
 # direct output to stderr
 exec 1>&2
 
-files_changed=$(git diff --cached --name-status | awk '$1 != "D" { print $2 }' | grep \.js$)
+files_changed=$(git diff --cached --no-renames --name-status --diff-filter=CMA HEAD | cut -f2 | grep '\.js$')
 if [[ $files_changed ]]; then
   node_modules/.bin/eslint $files_changed
   exit $?


### PR DESCRIPTION
Prior to this change it is not possible to commit a file rename,
eslint is told to check a file that does not exist anymore