### PR TITLE
SCRD-4240 Add passphrase dialog to login page

### DIFF
--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -102,7 +102,6 @@ export class GetSshPassphraseModal extends Component {
     postJson('/api/v2/sshagent/key', JSON.stringify(password), undefined, false)
       .then(this.props.doneAction)
       .catch((error) => {
-        this.props.cancelAction();
         if (error.status === 401) {
           this.setState({error: translate('get.passphrase.invalid'), passphrase: ''});
         } else {
@@ -138,7 +137,6 @@ export class GetSshPassphraseModal extends Component {
   render() {
     const footer = (
       <div className="btn-row">
-        <ActionButton type='default' clickAction={this.props.cancelAction} displayLabel={translate('cancel')}/>
         <ActionButton clickAction={::this.setPassphrase} displayLabel={translate('ok')}
           isDisabled={!this.isValidPassphrase()}/>
       </div>
@@ -148,7 +146,8 @@ export class GetSshPassphraseModal extends Component {
       <div>
         {this.renderErrorMessage()}
         <ConfirmModal title={translate('get.passphrase')}
-          onHide={this.props.cancelAction} footer={footer}>
+          onHide={this.props.cancelAction} footer={footer}
+          hideCloseButton={true}>
           <form onSubmit={::this.setPassphrase}>
             <div>{translate('get.passphrase.description')}</div>
             <div className='passphrase-line'>

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -64,7 +64,7 @@
     "legend.unknown": "Unknown",
     "legend.ok": "ok",
     "get.passphrase": "Provide SSH Passphrase",
-    "get.passphrase.description": "The operation you are about to perform requires the SSH passphrase. Please provide the SSH passphrase or select the Cancel button to abort the operation.",
+    "get.passphrase.description": "Many operations require SSH access, and the private key is supplied by an SSH agent.  The SSH agent cannot load the private key because it is protected by a passphrase. Please provide this SSH passphrase in order to load the private key into the SSH agent.\nIn the event that the ardana service and the SSH agent are restarted while logged into the CLM Admin Console, operations that require the SSH key will fail until you logout and log back in and enter the SSH passphrase here.",
     "get.passphrase.invalid": "SSH passphrase provided is incorrect. Please provide the correct SSH passphrase.",
     "get.passphrase.error": "Unable to use the provided SSH passphrase: {0}.\nPlease correct the problem and try again.",
     "id.with_colon": "ID:",

--- a/src/pages/ServiceInfo.js
+++ b/src/pages/ServiceInfo.js
@@ -24,7 +24,6 @@ import { AlarmDonut } from '../components/Graph';
 import { ErrorMessage } from '../components/Messages.js';
 import ContextMenu from '../components/ContextMenu.js';
 import { Tooltip, OverlayTrigger } from 'react-bootstrap';
-import { GetSshPassphraseModal } from '../components/Modals.js';
 
 const MONASCA_SERVICES_MAP = {
   ardana: 'ardana',
@@ -238,9 +237,7 @@ class ServiceInfo extends Component {
       statusList: undefined,
       showLoadingMask: false,
       error: undefined,
-      menuLocation: undefined,
-      showGetPassphraseModal: false,
-      requiresPassphrase: true
+      menuLocation: undefined
     };
   }
 
@@ -270,14 +267,6 @@ class ServiceInfo extends Component {
           // no need to show error for this case
         });
     }
-
-
-    fetchJson('/api/v2/sshagent/requires_password')
-      .then((responseData) => {
-        this.setState({
-          requiresPassphrase: responseData['requires_password']
-        });
-      });
   }
 
   renderErrorMessage() {
@@ -337,22 +326,13 @@ class ServiceInfo extends Component {
   }
 
   showRunStatusPlaybookModal = () => {
-    if (this.state.requiresPassphrase) {
-      this.setState({showGetPassphraseModal: true});
-    } else {
-      const playbookName = this.getPlaybookName();
-      this.setState({
-        showActionMenu: false,
-        showRunStatusPlaybookModal: true,
-        playbooks: [playbookName],
-        steps: [{label: 'status', playbooks: [playbookName + '.yml']}],
-      });
-    }
-  }
-
-  handlePassphrase = () => {
-    this.setState({showGetPassphraseModal: false, requiresPassphrase: false});
-    this.showRunStatusPlaybookModal();
+    const playbookName = this.getPlaybookName();
+    this.setState({
+      showActionMenu: false,
+      showRunStatusPlaybookModal: true,
+      playbooks: [playbookName],
+      steps: [{label: 'status', playbooks: [playbookName + '.yml']}],
+    });
   }
 
   renderMenuItems = () => {
@@ -428,11 +408,6 @@ class ServiceInfo extends Component {
 
     return (
       <>
-        <If condition={this.state.showGetPassphraseModal}>
-          <GetSshPassphraseModal
-            doneAction={this.handlePassphrase}
-            cancelAction={() => this.setState({showGetPassphraseModal: false})}/>
-        </If>
         <If condition={this.state.showRunStatusPlaybookModal}>
           <PlaybookProgress steps={this.state.steps} playbooks={this.state.playbooks}
             updatePageStatus={() => {}} modalMode showModal={true}


### PR DESCRIPTION
At the login prompt add a modal dialog to prompt for the SSH passphrase
if one is needed in order to load the private SSH key.  Improve the
text to explain how it is used and how to deal with restarts while
logged in.  Remove the ability to close the dialog without entering
a valid passphrase. Remove the ssh password dialog from the ServiceInfo
page.