### PR TITLE
SCRD-4240 Improve reporting of ssh passphrase errors

### DIFF
--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -146,10 +146,10 @@ export class GetSshPassphraseModal extends Component {
 
     return (
       <div>
-        {this.renderErrorMessage()}
         <ConfirmModal title={translate('get.passphrase')}
           onHide={this.props.cancelAction} footer={footer}
           hideCloseButton={true}>
+          {this.renderErrorMessage()}
           <form onSubmit={::this.setPassphrase}>
             <div>{translate('get.passphrase.description')}</div>
             <div className='passphrase-line'>


### PR DESCRIPTION
Change the nesting of the error message so that it appears in front of
the ssh passphrase dialog rather than behind it.