### PR TITLE
Fix cancel/revert issues with service reconfigure (SCRD-5880)

### DIFF
--- a/src/components/PlaybookProgress.js
+++ b/src/components/PlaybookProgress.js
@@ -631,7 +631,7 @@ class PlaybookProgress extends Component {
   }
 
   renderCancelButton() {
-    if (!this.state.errorMsg &&
+    if (!this.state.errorMsg && !this.props.hideCancel &&
       this.getPlaybooksWithStatus(STATUS.IN_PROGRESS).length > 0 &&
       this.getPlaybooksWithStatus(STATUS.FAILED).length == 0) {
 

--- a/src/pages/ServiceConfiguration.js
+++ b/src/pages/ServiceConfiguration.js
@@ -164,6 +164,7 @@ class ServiceConfiguration extends Component {
         <div className='column-layout'>
           <div className='header'>{translate('services.configuration.update.progress')}</div>
           <PlaybookProgress steps={this.playbooksToRun.steps} playbooks={this.playbooksToRun.playbooks}
+            hideCancel={true}
             payload={payload} updatePageStatus={() => {}} updateGlobalState={this.updateProgressStatus}/>
           {this.state.showActionButtons ? this.renderActionButtons() : ''}
         </div>


### PR DESCRIPTION
Remove cancel from the playbook progress page for service reconfiguration (i.e. the page where the update has been kicked off and is running).
When cancel is clicked on the Configuration tab (when configuration files have been edited but no updated launched), reload the playbooks in addition to resetting their updated status