### PR TITLE
Fix click listener collision on service list (SCRD-7644)

### DIFF
--- a/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
+++ b/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
@@ -341,8 +341,7 @@ class ServiceTemplatesTab extends Component {
           }
           fileList.push(
             <li key={idx}>
-              <ActionButton type='clickable' clickAction={() => this.handleEditFile(item.service, file)}
-                displayLabel={file + (isChanged ? ' *' : '')}/>
+              <a onClick={() => this.handleEditFile(item.service, file)}>{file + (isChanged ? ' *' : '')}</a>
             </li>
           );
         });

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -97,6 +97,7 @@
     margin-bottom: 15px;
     padding-left: 25px;
     li {
+      margin-top: 5px;
       height: 1.5em;
     }
   }
@@ -111,6 +112,16 @@
     display: inline-flex;
     line-height: 1.4em;
     cursor: pointer;
+  }
+
+  .file-list a {
+    color: @sb-cerulean-900;
+    line-height: 1.5em;
+    &:hover {
+      color: @sb-blue-400;
+      text-decoration: underline;
+      cursor: pointer;
+    }
   }
 }
 


### PR DESCRIPTION
The click listeners in the "configuration" page of the service list are conflicting due to the buttons for the services overflowing the container they're in.
changed buttons to anchors
increased line-height of the service links
tweaked margin around the list items