### PR TITLE
Change tooltip placement to auto (SCRD-7643)

### DIFF
--- a/src/components/HelpText.js
+++ b/src/components/HelpText.js
@@ -21,7 +21,7 @@ export default function HelpText(props) {
   );
 
   return (
-    <OverlayTrigger placement="top" overlay={tooltip}>
+    <OverlayTrigger placement="auto" overlay={tooltip}>
       <span className='tooltip-icon'>
         <i className='material-icons md-dark'>info</i>
       </span>


### PR DESCRIPTION
prevents the "tooltip flash" on certain pages. Does mean that tooltip placement is now dynamic and will not default to the same position for everything, but seems a reasonable tradeoff.