### PR TITLE
Remove broken goback logic when token expires (SCRD-5747)

### DIFF
--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -16,7 +16,7 @@ import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
 import { fetchJson, postJson } from '../utils/RestUtils.js';
 import { setAuthToken, clearAuthToken } from '../utils/Auth.js';
-import { navigateTo, navigateBack, wasRedirectedToLogin } from '../utils/RouteUtils.js';
+import { navigateTo, wasRedirectedToLogin } from '../utils/RouteUtils.js';
 import { ErrorMessage } from '../components/Messages.js';
 import { LoadingMask } from '../components/LoadingMask.js';
 import { GetSshPassphraseModal } from '../components/Modals.js';
@@ -49,15 +49,11 @@ class LoginPage extends Component {
   }
 
   navigate = () => {
-    if (wasRedirectedToLogin()) {
-      navigateBack();
+    const search = new URLSearchParams(window.location.search);
+    if (search.get('start')?.startsWith('installer')) {
+      navigateTo('/', undefined, search.toString());
     } else {
-      const search = new URLSearchParams(window.location.search);
-      if (search.get('start')?.startsWith('installer')) {
-        navigateTo('/', undefined, search.toString());
-      } else {
-        navigateTo('/services/info');
-      }
+      navigateTo('/services/info');
     }
   }
 

--- a/src/utils/RouteUtils.js
+++ b/src/utils/RouteUtils.js
@@ -35,11 +35,6 @@ export function navigateTo(url, state, search) {
   history.go(0);
 }
 
-export function navigateBack(fallback='/', state) {
-  const history = createHistory();
-  history.goBack();
-}
-
 export function redirectToLogin(forced = true) {
   navigateTo('/login', { forcedRedirect: forced });
 }


### PR DESCRIPTION
The logic to "goBack" to the page that timed out isn't working and causes the user to have to login twice (only to be taken to the default landing page anyway). For now, removed the extra logic, which fixes the double login problem.