### PR TITLE
Update bootstrap to 4.3.1 due to XSS security issue (SCRD-8112)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "bootstrap": "4.1.2",
+    "bootstrap": "4.3.1",
     "eos-icons": "^2.0.3",
     "history": "^4.7.2",
     "html-webpack-plugin": "^3.2.0",


### PR DESCRIPTION
Update bootstrap due to XSS vulnerability. 

A sanity check found no obvious visual differences between 4.1.2 and 4.3.1 but should be double-checked