### PR TITLE
Load the model before service statuses (SCRD-8483)

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -329,13 +329,26 @@ class InstallWizard extends Component {
   // Pages within the installer may request that the model be forceably loaded
   // from disk, espcially when a change is made to directly to the model files
   // to the model.  Returns a promise
-  loadModel = () => fetchJson('/api/v2/model')
-    .then(responseData => {
-      this.setState({'model': fromJS(responseData)});
-    })
-    .catch((error) => {
-      console.log('Unable to retrieve saved model');// eslint-disable-line no-console
-    })
+  loadModel = () => {
+    // If there is a pending promise to fetch the model return that promise.
+    if(!this.fetchModelPromise) {
+      this.fetchModelPromise = new Promise((resolve, reject) => {
+        fetchJson('/api/v2/model')
+          .then(responseData => {
+            this.setState({'model': fromJS(responseData)}, () => {
+              this.fetchModelPromise = undefined;
+              resolve();
+            });
+          })
+          .catch((error) => {
+            console.log('Unable to retrieve saved model');// eslint-disable-line no-console
+            this.fetchModelPromise = undefined;
+            reject(error);
+          });
+      });
+    }
+    return this.fetchModelPromise;
+  }
 
   // Pages within the installer may request that the model be saved to disk,
   // which is especially important when some significant change has been made

--- a/src/pages/UpdateServers.js
+++ b/src/pages/UpdateServers.js
@@ -124,15 +124,16 @@ class UpdateServers extends BaseUpdateWizardPage {
           };
         });
       }
+      let internalModel = this.state.internalModel;
       if(!this.state.internalModel) {
-        const model = await getInternalModel();
-        this.setState({ internalModel: fromJS(model) });
+        internalModel = fromJS(await getInternalModel());
+        this.setState({ internalModel });
       }
       if(!this.state.osUsername) {
         this.getUsername();
       }
       let promises = [
-        this.getServerStatuses(),
+        this.getServerStatuses(internalModel),
         this.checkMonasca()
       ];
       await Promise.all(promises);
@@ -253,8 +254,10 @@ class UpdateServers extends BaseUpdateWizardPage {
     }
   }
 
-  async getServerStatuses() {
-    let internalModelServers = this.state.internalModel?.getIn(['internal', 'servers']).toJS();
+  async getServerStatuses(internalModel) {
+    // make sure the model it loaded, we need to fetch some things from it.
+    await this.props.loadModel();
+    let internalModelServers = internalModel?.getIn(['internal', 'servers']).toJS();
     let servers = this.props.model?.getIn(['inputModel','servers']).toJS()
       .filter(s => s.role.includes('COMPUTE'))
       .map(s => {


### PR DESCRIPTION
- Wait for model to be loaded before fetching server statuses.
- If there is a pending promise to load the model, return that promise.
Can potentially dedupe simultaneous requests.