### PR TITLE
Clarify Day2 Model changes are not deployed automatically (SCRD-8694)

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -139,6 +139,7 @@
     "validate.config.files.heading": "Review configuration files",
     "validate.config.files.validate": "Validate",
     "validate.config.files.deploy": "Deploy",
+    "validate.config.files.msg.info0": "Validated model changes will be committed but are not automatically deployed. The model may be edited here in support of server add/replace use cases, or as needed to support service configuration changes. The deployment update process should be completed on the servers or configuration pages respectively.",
     "validate.config.files.msg.info1": "Click on a configuration file to view or edit its content.",
     "validate.config.files.msg.info2": "Click the Validate button to run the configuration processor.",
     "validate.config.files.msg.valid": "Validation succeeded and changes have been committed.",

--- a/src/pages/ModelConfiguration.js
+++ b/src/pages/ModelConfiguration.js
@@ -27,7 +27,7 @@ class ModelConfiguration extends Component {
     return <div className='menu-tab-content'>
       <ValidateConfigFiles disableTab={this.noop()} showNavButtons={this.noop()} enableBackButton={this.noop()}
         enableNextButton={this.noop()} setRequiresPassword={this.noop()} loadModel={this.noop()}
-        requiresPassword={false} sshPassphrase={undefined} />
+        requiresPassword={false} sshPassphrase={undefined} allowsDeploy={false} />
     </div>;
   }
 }

--- a/src/pages/ValidateConfigFiles.js
+++ b/src/pages/ValidateConfigFiles.js
@@ -141,10 +141,15 @@ class EditFile extends Component {
 class DisplayFileList extends Component {
   getMessage() {
     if (this.props.valid === UNKNOWN) {
+      let infoMessages = [];
+      if(!this.props.allowsDeploy) {
+        infoMessages.push(<InfoBanner key='info0' message={translate('validate.config.files.msg.info0')}/>);
+      }
+      infoMessages.push(<InfoBanner key='info1' message={translate('validate.config.files.msg.info1')}/>);
+      infoMessages.push(<InfoBanner key='info2' message={translate('validate.config.files.msg.info2')}/>);
       return (
         <div>
-          <InfoBanner message={translate('validate.config.files.msg.info1')}/>
-          <InfoBanner message={translate('validate.config.files.msg.info2')}/>
+          {infoMessages}
         </div>);
     } else if (this.props.valid === VALIDATING) {
       return (
@@ -329,6 +334,7 @@ export class ValidateConfigFiles extends Component {
             onEditClick={(file) => this.editFile(file)}
             valid={this.state.valid}
             invalidMsg={this.state.invalidMsg}
+            allowsDeploy={this.props.allowsDeploy}
           />
         </If>
         <If condition={this.state.editingFile !== ''}>
@@ -632,7 +638,8 @@ class ConfigPage extends BaseWizardPage {
                 loadModel={this.props.loadModel}
                 requiresPassword={this.state.requiresPassword}
                 sshPassphrase={this.state.sshPassphrase}
-                setRequiresPassword={this.setRequiresPassword}/>
+                setRequiresPassword={this.setRequiresPassword}
+                allowsDeploy={true}/>
 
             </Tab>
             <Tab disabled={this.state.disableTab}


### PR DESCRIPTION
The model tab under "services" in the Day 2 UI does not automatically deploy updates to the cloud, though users can make, commit, and validate changes there. Added clarifying text in the Day2 scenario (Day0 is unchanged)