### PR TITLE
Make useful links persist (SCRD-8302)

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -77,7 +77,8 @@ class InstallWizard extends Component {
 
     // Indicate which of the state variables will be persisted to, and loaded from, the progress API
     this.persistedStateVars = [
-      'currentStep', 'steps', 'playbookStatus', 'connectionInfo', 'deployConfig'
+      'currentStep', 'steps', 'playbookStatus', 'connectionInfo',
+      'deployConfig', 'usefulLinks'
     ];
   }
 

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -457,6 +457,7 @@
     "deploy.progress.commit": "Model committed",
     "deploy.progress.ready-deployment": "Ready deployment",
     "deploy.progress.predeployment": "Pre-Deployment",
+    "deploy.progress.external-urls": "Persisting endpoints",
     "deploy.progress.step1": "Network configuration",
     "deploy.progress.step2": "Compute nodes deployed",
     "deploy.progress.step3": "Monitoring nodes deployed",

--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -23,6 +23,7 @@ import { PlaybookProgress } from '../components/PlaybookProgress.js';
 import { ErrorBanner } from '../components/Messages.js';
 import { getInternalModel } from './topology/TopologyUtils.js';
 
+const GET_EXTERNAL_LINKS = 'get_external_links';
 const GET_GEN_CLOUD_MODEL = 'get_generated_cloud_model';
 
 
@@ -141,6 +142,11 @@ class CloudDeployProgress extends BaseWizardPage {
       });
     }
 
+    steps.push({
+      label: translate('deploy.progress.external-urls'),
+      playbooks: [GET_EXTERNAL_LINKS]
+    });
+
     steps = steps.concat([{
       label: translate('deploy.progress.step1'),
       playbooks: [constants.NETWORK_INTERFACE_DEPLOY_PLAYBOOK + '.yml']
@@ -203,7 +209,7 @@ class CloudDeployProgress extends BaseWizardPage {
     }
 
     playbooks.push({
-      name: 'get_external_links',
+      name: GET_EXTERNAL_LINKS,
       action: ((logger) => {
         return fetchJson('api/v2/external_urls')
           .then((response) => {

--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -214,6 +214,13 @@ class CloudDeployProgress extends BaseWizardPage {
         return fetchJson('api/v2/external_urls')
           .then((response) => {
             this.props.updateGlobalState('usefulLinks', response);
+          })
+          .catch((error) => {
+            logger('Warning: Failed to fetch from api/v2/external_urls.');
+            logger('Unable to complete the ' +
+              `"${translate('deploy.progress.external-urls')}" step: ` +
+              `${error.toString()}.`
+            );
           });
       })
     });

--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -217,8 +217,7 @@ class CloudDeployProgress extends BaseWizardPage {
           })
           .catch((error) => {
             logger('Warning: Failed to fetch from api/v2/external_urls.');
-            logger('Unable to complete the ' +
-              `"${translate('deploy.progress.external-urls')}" step: ` +
+            logger('Unable to complete the "Persisting endpoints" step: ' +
               `${error.toString()}.`
             );
           });


### PR DESCRIPTION
If the deployment page was refreshed the useful links in state
could be lost. Persisting them fixes this.