### PR TITLE
Update documentation useful link (SCRD-8689)

### DIFF
--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -451,7 +451,7 @@
     "complete.message.link.heading": "Useful links:",
     "complete.message.link1": "OpenStack Horizon UI",
     "complete.message.link2": "Ops Console UI",
-    "complete.message.docs.link": "SUSE documentation",
+    "complete.message.docs.link": "SUSE OpenStack Cloud 9 documentation",
 
     "deploy.progress.heading": "Cloud deployment in progress",
     "deploy.progress.config-processor-run": "Config processor run",

--- a/src/pages/Complete.js
+++ b/src/pages/Complete.js
@@ -39,7 +39,7 @@ class Complete extends BaseWizardPage {
 
     links.push({
       name: 'suse-documentation',
-      url: 'https://www.suse.com/documentation/'
+      url: 'https://www.suse.com/documentation/suse-openstack-cloud-9/'
     });
 
     return links.map((link) => {


### PR DESCRIPTION
Instead of going to the general SUSE documentation page the link should
point to the SUSE OpenStack Cloud 9 documentation page